### PR TITLE
fix: update Codex connector to use exec mode

### DIFF
--- a/src/connectors/codex-cli.ts
+++ b/src/connectors/codex-cli.ts
@@ -14,7 +14,10 @@ export class CodexCLIConnector extends CLIBaseConnector {
       command: 'codex',
       displayName: 'OpenAI Codex CLI',
       buildArgs: (prompt: string, _config: LLMConfig) => {
-        return ['-q', prompt];
+        return ['exec', '--skip-git-repo-check', '--sandbox', 'read-only', prompt];
+      },
+      buildStdinArgs: (_config: LLMConfig) => {
+        return ['exec', '--skip-git-repo-check', '--sandbox', 'read-only', '-'];
       },
     });
   }


### PR DESCRIPTION
## Summary
- replace legacy `codex -q` invocation with `codex exec`
- add explicit stdin mode for long prompts instead of falling back to `buildArgs('-')`
- include `--skip-git-repo-check --sandbox read-only` for non-interactive workflow execution

## Root cause
The current connector builds `['-q', prompt]`, while current Codex CLI supports `codex <prompt>`, `codex exec <prompt>`, and `codex exec -` for stdin. Because `CLIBaseConnector` falls back to `buildArgs('-', config)` when `buildStdinArgs` is missing, long prompts degrade to `codex -q -`, which is invalid.

## Verification
Locally re-verified against the user's installed environment by running the smoke workflow through `ao run ... --provider codex-cli` after patching. The workflow completed successfully.
