### PR TITLE
feat(run): human_input 人工输入节点（真·中途干预的 CLI 地基）

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,8 +402,8 @@ ao serve --verbose    # 带调试日志
 | `depends_on` | string[] | 否 | 依赖的步骤 ID |
 | `depends_on_mode` | string | 否 | `"all"`（默认）或 `"any_completed"`（任一完成即可） |
 | `condition` | string | 否 | 条件表达式，不满足则跳过（如 `"{{var}} contains 技术"`） |
-| `type` | string | 否 | `"approval"` 表示人工审批节点 |
-| `prompt` | string | 否 | 审批节点的提示文本 |
+| `type` | string | 否 | `"approval"` 人工审批节点 / `"human_input"` 人工输入节点（跑到该步暂停，读取你的输入作为该步产出注入下游） |
+| `prompt` | string | 否 | `approval` / `human_input` 节点的提示文本 |
 | `loop` | object | 否 | 循环配置 |
 | `loop.back_to` | string | 否 | 循环回到的步骤 ID |
 | `loop.max_iterations` | number | 否 | 最大循环次数（1-10） |

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "eval": "npx tsx eval/run-eval.ts",
-    "test": "npx tsx test/run.ts && npx tsx test/condition.ts && npx tsx test/cli.ts && npx tsx test/cli-base.ts && npx tsx test/compose.ts && npx tsx test/demo.ts && npx tsx test/factory-custom.ts && npx tsx test/step-llm.ts && npx tsx test/step-llm-yaml.ts && npx tsx test/stdin-limit.ts && npx tsx test/compose-name.ts && npx tsx test/upgrade.ts && npx tsx test/resume.ts && npx tsx test/feedback.ts && npx tsx test/validate-report.ts && npx tsx test/workflows.ts && npx tsx test/timeout.ts && npx tsx test/inputs.ts && npx tsx test/e2e.ts && npx tsx test/e2e-condition.ts && npx tsx test/e2e-loop.ts && npx tsx test/mcp.ts",
+    "test": "npx tsx test/run.ts && npx tsx test/condition.ts && npx tsx test/cli.ts && npx tsx test/cli-base.ts && npx tsx test/compose.ts && npx tsx test/demo.ts && npx tsx test/factory-custom.ts && npx tsx test/step-llm.ts && npx tsx test/step-llm-yaml.ts && npx tsx test/stdin-limit.ts && npx tsx test/compose-name.ts && npx tsx test/upgrade.ts && npx tsx test/resume.ts && npx tsx test/feedback.ts && npx tsx test/human-input.ts && npx tsx test/validate-report.ts && npx tsx test/workflows.ts && npx tsx test/timeout.ts && npx tsx test/inputs.ts && npx tsx test/e2e.ts && npx tsx test/e2e-condition.ts && npx tsx test/e2e-loop.ts && npx tsx test/mcp.ts",
     "prepublishOnly": "npm run build"
   },
   "files": [

--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -336,6 +336,11 @@ async function executeStep(
     return await handleApproval(node, opts.context);
   }
 
+  // 人工输入节点：跑到这步暂停、读取用户输入，作为该步产出注入下游
+  if (node.step.type === 'human_input') {
+    return await handleHumanInput(node, opts.context);
+  }
+
   // 加载角色定义（步骤级 name/emoji 优先）
   const agent = loadAgent(opts.agentsDir, node.step.role);
   node.agentName = node.step.name || agent.name;
@@ -483,6 +488,48 @@ async function handleApproval(
 
   return new Promise((resolve) => {
     rl.question(`\n⏸️  ${prompt} `, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+/**
+ * 人工输入节点：跑到这步时暂停，读取用户自由输入，作为该步产出注入下游。
+ * 与 approval 的区别——approval 是"放行/拦截"的闸门，human_input 是把人写的内容
+ * 喂进工作流（如"往哪个方向写""补一段背景"）。
+ *
+ * 若该步的 output 变量已被预填（`-i 变量=值` 或 --resume 恢复），直接采用、不阻塞，
+ * 这样自动化 / 测试 / 断点续跑都能跳过交互。Web 模式下 server 向子进程 stdin 写入即可复用同一路径。
+ */
+async function handleHumanInput(
+  node: DAGNode,
+  context: Map<string, string>
+): Promise<string> {
+  // 预填即采用：避免在非交互场景（CI/测试/resume）卡在 stdin
+  const outVar = node.step.output;
+  if (outVar) {
+    const pre = context.get(outVar);
+    if (pre && pre.trim()) return pre;
+  }
+
+  const prompt = node.step.prompt
+    ? renderTemplate(node.step.prompt, context)
+    : '请输入：';
+
+  // 可选的 task 作为给用户看的上下文提示
+  if (node.step.task) {
+    const content = renderTemplate(node.step.task, context).trim();
+    if (content) console.log('\n' + content);
+  }
+
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) => {
+    rl.question(`\n📝 ${prompt} `, (answer) => {
       rl.close();
       resolve(answer.trim());
     });

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -44,10 +44,12 @@ export function parseWorkflow(filePath: string): WorkflowDefinition {
     if (stepIds.has(step.id)) throw new Error(`step id 重复: ${step.id}`);
     stepIds.add(step.id);
 
-    if (step.type !== 'approval' && !step.role) {
+    // approval / human_input 是无角色的人工节点，不需要 role / task
+    const isHumanNode = step.type === 'approval' || step.type === 'human_input';
+    if (!isHumanNode && !step.role) {
       throw new Error(`step "${step.id}" 缺少 role`);
     }
-    if (!step.task && step.type !== 'approval') {
+    if (!step.task && !isHumanNode) {
       throw new Error(`step "${step.id}" 缺少 task`);
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,8 +36,8 @@ export interface StepDefinition {
   task: string;               // 任务描述，支持 {{变量}} 模板
   output?: string;            // 输出变量名
   depends_on?: string[];      // 依赖的步骤 id
-  type?: 'normal' | 'approval'; // 节点类型
-  prompt?: string;            // approval 类型的提示文本
+  type?: 'normal' | 'approval' | 'human_input'; // 节点类型
+  prompt?: string;            // approval / human_input 类型的提示文本
   condition?: string;           // 如 "{{category}} contains bug"
   depends_on_mode?: 'all' | 'any_completed';  // 默认 'all'（任一跳过→跳过），'any_completed' = 只要有一个完成就执行
   llm?: Partial<LLMConfig>;   // 步骤级 LLM 配置，覆盖全局 llm

--- a/test/human-input.ts
+++ b/test/human-input.ts
@@ -1,0 +1,94 @@
+/**
+ * 测试 human_input 人工输入节点：
+ *  - parser 接受无 role/task 的 human_input 节点
+ *  - executeDAG：预填 output 变量时不阻塞、直接采用，并把值注入下游；该步不调 LLM
+ */
+import { executeDAG } from '../src/core/executor.js';
+import { buildDAG } from '../src/core/dag.js';
+import { parseWorkflow } from '../src/core/parser.js';
+import type { WorkflowDefinition, LLMConnector, LLMResult, LLMConfig } from '../src/types.js';
+import { resolve } from 'node:path';
+import { existsSync, writeFileSync, unlinkSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let passed = 0;
+let failed = 0;
+
+function test(name: string, fn: () => Promise<void>): Promise<void> {
+  return fn().then(() => { console.log(`  ✅ ${name}`); passed++; })
+    .catch((err) => { console.log(`  ❌ ${name}: ${err instanceof Error ? err.message : err}`); failed++; });
+}
+function assert(condition: boolean, msg: string): void {
+  if (!condition) throw new Error(msg);
+}
+
+const userMessages: string[] = [];
+let chatCalls = 0;
+class CaptureConnector implements LLMConnector {
+  async chat(_sys: string, user: string, _config: LLMConfig): Promise<LLMResult> {
+    chatCalls++; userMessages.push(user);
+    return { content: 'written', usage: { input_tokens: 1, output_tokens: 1 } };
+  }
+}
+
+const agentsDir = [
+  resolve(import.meta.dirname!, '../node_modules/agency-agents-zh'),
+  resolve(import.meta.dirname!, '../agency-agents-zh'),
+  resolve(import.meta.dirname!, '../../agency-agents-zh'),
+].find(d => existsSync(d)) || resolve(import.meta.dirname!, '../../agency-agents-zh');
+
+console.log('\n─── human_input 人工输入节点 ───');
+
+await test('parser 接受无 role/task 的 human_input 节点', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'ao-hi-'));
+  const file = join(dir, 'hi.yaml');
+  writeFileSync(file, [
+    'name: hi-test',
+    'agents_dir: agency-agents-zh',
+    'llm:',
+    '  provider: deepseek',
+    '  model: deepseek-chat',
+    'steps:',
+    '  - id: ask',
+    '    type: human_input',
+    '    prompt: "往哪个方向写?"',
+    '    output: hint',
+    '  - id: write',
+    '    role: product/product-manager',
+    '    task: "用 {{hint}} 写"',
+    '    output: result',
+    '    depends_on: [ask]',
+  ].join('\n'), 'utf-8');
+  const wf = parseWorkflow(file);  // 不应抛 "缺少 role/task"
+  assert(wf.steps[0].type === 'human_input', 'ask 应为 human_input 节点');
+  unlinkSync(file);
+});
+
+await test('executeDAG：预填即采用，注入下游，且该步不调 LLM', async () => {
+  chatCalls = 0; userMessages.length = 0;
+  const workflow: WorkflowDefinition = {
+    name: 'hi',
+    agents_dir: agentsDir,
+    llm: { provider: 'deepseek', model: 'deepseek-chat' },
+    steps: [
+      { id: 'ask', role: '', type: 'human_input', task: '', prompt: '往哪个方向?', output: 'hint' },
+      { id: 'write', role: 'product/product-manager', task: '用 {{hint}} 写', output: 'result', depends_on: ['ask'] },
+    ],
+  };
+  const dag = buildDAG(workflow);
+  const result = await executeDAG(dag, {
+    connector: new CaptureConnector(),
+    agentsDir,
+    llmConfig: workflow.llm,
+    concurrency: 1,
+    inputs: new Map([['hint', '科幻悬疑']]),  // 预填 → 不阻塞 stdin
+  });
+  assert(chatCalls === 1, `应只调 1 次 LLM（write），实际 ${chatCalls}`);
+  assert(userMessages[0].includes('科幻悬疑'), 'write 应收到注入的人工输入');
+  const ask = result.steps.find(s => s.id === 'ask');
+  assert(ask?.status === 'completed', 'ask 步骤应完成');
+});
+
+console.log(`\nhuman_input 测试: ${passed} 通过, ${failed} 失败`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## 背景

用户反馈的另一半：「跑的时候无法干预，像抽卡。」`--feedback`（#22）解决了"跑完返工"，本 PR 是"跑中介入"的第一块地基。

## 用法

```yaml
steps:
  - id: ask
    type: human_input          # 新节点类型
    prompt: "想往哪个方向写?"
    output: hint               # 你的输入 → {{hint}} 给下游用
  - id: write
    role: "content/content-creator"
    task: "用 {{hint}} 的方向写一篇"
    depends_on: [ask]
```

跑到 `ask` 暂停、读取你的输入，作为该步产出注入下游。与 `approval`（放行/拦截闸门）互补——`human_input` 是把人写的内容喂进工作流。

## 设计要点

- **免 role/task**：和 `approval` 一样是无角色人工节点
- **预填即采用**：若 output 变量已被 `-i 变量=值` 或 `--resume` 预填，直接采用、不阻塞 stdin → 兼容 CI / 测试 / 断点续跑
- **Web 复用**：server 向子进程 stdin 写入即可走同一路径（网页实时介入的下一步基于此）

## 验证

- 全量 `npm test` 通过（含 51 模板门禁）
- 新增 `test/human-input.ts`（parser 免 role/task + executor 预填注入、该步不调 LLM）
- CLI 真机：`echo "科幻悬疑风" | ao run hi.yaml` → 输入被捕获并存为该步产出

## 范围

仅 CLI 引擎层。网页"实时暂停任意步骤介入"（`POST /api/run-input` 写子进程 stdin + SSE `await-input` 事件）是基于此地基的独立下一步。