### PR TITLE
feat(web): 网页实时介入——human_input/approval 暂停弹框写回 stdin

### DIFF
--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -467,6 +467,18 @@ export function buildFeedbackBlock(feedback: string, previousOutput?: string): s
   return parts.join('');
 }
 
+/**
+ * Web 模式（AO_WEB_INPUT=1，由 web/server.js spawn 时注入）下，向 stdout 发一行机器可读
+ * 标记，server 解析后转成 SSE `await-input` 事件推给前端弹框；用户输入再经 server 写回
+ * 子进程 stdin，被这里的 readline 读到。CLI（无该 env）下不发标记，行为不变。
+ * 标记必须换行结尾，确保 server 的按行解析能立刻 flush。
+ */
+function emitWebInputRequest(stepId: string, prompt: string, kind: 'human_input' | 'approval'): void {
+  if (process.env.AO_WEB_INPUT === '1') {
+    process.stdout.write(`\n__AO_INPUT_REQUEST__${JSON.stringify({ type: kind, stepId, prompt })}\n`);
+  }
+}
+
 async function handleApproval(
   node: DAGNode,
   context: Map<string, string>
@@ -481,13 +493,17 @@ async function handleApproval(
     console.log('\n' + content);
   }
 
+  emitWebInputRequest(node.step.id, prompt, 'approval');
+
   const rl = createInterface({
     input: process.stdin,
     output: process.stdout,
   });
 
   return new Promise((resolve) => {
-    rl.question(`\n⏸️  ${prompt} `, (answer) => {
+    // Web 模式由前端弹框驱动，不在终端再打印人类提示
+    const display = process.env.AO_WEB_INPUT === '1' ? '' : `\n⏸️  ${prompt} `;
+    rl.question(display, (answer) => {
       rl.close();
       resolve(answer.trim());
     });
@@ -523,13 +539,16 @@ async function handleHumanInput(
     if (content) console.log('\n' + content);
   }
 
+  emitWebInputRequest(node.step.id, prompt, 'human_input');
+
   const rl = createInterface({
     input: process.stdin,
     output: process.stdout,
   });
 
   return new Promise((resolve) => {
-    rl.question(`\n📝 ${prompt} `, (answer) => {
+    const display = process.env.AO_WEB_INPUT === '1' ? '' : `\n📝 ${prompt} `;
+    rl.question(display, (answer) => {
       rl.close();
       resolve(answer.trim());
     });

--- a/web/server.js
+++ b/web/server.js
@@ -284,6 +284,11 @@ app.get('/api/workflows/yaml', (req, res) => {
   res.type('text/yaml').send(readFileSync(resolved, 'utf-8'));
 });
 
+// Active workflow child processes by runId, so POST /api/run-input can write to
+// the right process's stdin when a human_input / approval node pauses for input.
+let runSeq = 0;
+const activeRuns = new Map();
+
 // ── Run workflow (with optional resume) ──
 app.post('/api/run', (req, res) => {
   const { file, inputs, provider, resume, fromStep, feedback } = req.body || {};
@@ -333,7 +338,8 @@ app.post('/api/run', (req, res) => {
     }
   }
 
-  send('start', { cmd: `ao run ${args.slice(2).join(' ')}`, resume: !!resume, fromStep });
+  const runId = String(++runSeq);
+  send('start', { cmd: `ao run ${args.slice(2).join(' ')}`, resume: !!resume, fromStep, runId });
 
   // Parse CLI output into structured events
   let lineBuffer = '';
@@ -342,6 +348,14 @@ app.post('/api/run', (req, res) => {
   function parseLine(raw) {
     const clean = raw.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '').replace(/\r/g, '').trim();
     if (!clean) return;
+
+    // human_input / approval 节点暂停等待输入：引擎在 AO_WEB_INPUT 模式下发的机器标记。
+    // 转成 await-input 事件，前端弹框，用户输入经 POST /api/run-input 写回子进程 stdin。
+    const inputReq = clean.match(/^__AO_INPUT_REQUEST__(\{.*\})$/);
+    if (inputReq) {
+      try { send('await-input', { runId, ...JSON.parse(inputReq[1]) }); } catch { /* ignore malformed */ }
+      return;
+    }
 
     // Step start: "⏳ emoji name 执行中 ..."
     const startMatch = clean.match(/^⏳\s+(\S+)\s+(.+?)\s+执行中/);
@@ -397,8 +411,10 @@ app.post('/api/run', (req, res) => {
   console.log('[run]', NODE_BIN, args.join(' '));
   const child = spawn(NODE_BIN, args, {
     cwd: DATA_DIR,
-    env: { ...process.env, FORCE_COLOR: '0' },
+    // AO_WEB_INPUT=1 → 引擎遇到 human_input/approval 会发机器标记而非在终端等输入
+    env: { ...process.env, FORCE_COLOR: '0', AO_WEB_INPUT: '1' },
   });
+  activeRuns.set(runId, child);
 
   child.stdout.on('data', chunk => {
     const text = chunk.toString();
@@ -428,13 +444,28 @@ app.post('/api/run', (req, res) => {
   });
 
   let finished = false;
-  child.on('exit', () => { finished = true; });
+  child.on('exit', () => { finished = true; activeRuns.delete(runId); });
   res.on('close', () => {
     if (!finished && !child.killed) {
       console.log('[abort] client closed');
       child.kill('SIGTERM');
     }
   });
+});
+
+// ── Feed input to a paused run (human_input / approval node awaiting stdin) ──
+app.post('/api/run-input', (req, res) => {
+  const { runId, text } = req.body || {};
+  const child = runId != null ? activeRuns.get(String(runId)) : null;
+  if (!child || child.killed || !child.stdin || !child.stdin.writable) {
+    return res.status(404).json({ error: 'run not found or not awaiting input' });
+  }
+  try {
+    child.stdin.write(String(text ?? '') + '\n');
+    res.json({ ok: true });
+  } catch (e) {
+    res.status(500).json({ error: e?.message || String(e) });
+  }
 });
 
 // ── Roles / Agents ──

--- a/website/src/components/studio/RunManager.tsx
+++ b/website/src/components/studio/RunManager.tsx
@@ -1,5 +1,12 @@
 import { createContext, useCallback, useContext, useReducer, useRef, type ReactNode } from "react";
-import { runRole, runWorkflow, type SseHandler, type WorkflowStepMeta } from "@/lib/studio";
+import { api, runRole, runWorkflow, type SseHandler, type WorkflowStepMeta } from "@/lib/studio";
+
+/** 某步暂停等待人工输入（human_input / approval 节点）。 */
+export interface PendingInput {
+  stepId: string;
+  prompt: string;
+  type: "human_input" | "approval";
+}
 
 export type StepStatus = "pending" | "running" | "done";
 
@@ -47,6 +54,10 @@ export interface RunInstance {
   _stderr: string;
   /** 工作流运行才有：原始请求，供「对某步提意见重做」复用 file/provider/cast/inputs */
   source?: WorkflowRequest;
+  /** 服务端运行 id，用于把人工输入写回该子进程 stdin */
+  runId?: string;
+  /** 非空时表示某步正等待人工输入，前端应弹输入框 */
+  pendingInput?: PendingInput | null;
 }
 
 interface RunManagerValue {
@@ -58,6 +69,8 @@ interface RunManagerValue {
   open: (id: string | null) => void;
   /** 对已完成工作流运行中的某一步提意见，带着「上一版产出 + 意见」让该专家返工 */
   rerunWithFeedback: (id: string, stepId: string, feedback: string) => string | null;
+  /** 把人工输入提交回正在等待的运行（human_input / approval 节点） */
+  submitInput: (id: string, text: string) => void;
 }
 
 const Ctx = createContext<RunManagerValue | null>(null);
@@ -122,7 +135,15 @@ export function RunProvider({ children }: { children: ReactNode }) {
 
       const onEvent: SseHandler = (event, data) => {
         switch (event) {
+          case "start":
+            inst.runId = data.runId;
+            break;
+          case "await-input":
+            inst.pendingInput = { stepId: data.stepId, prompt: data.prompt, type: data.type };
+            break;
           case "step-header":
+            // 某步推进了 → 清掉等待态（用户已提交、或本就不需要输入）
+            inst.pendingInput = null;
             upsert(data.id, {
               emoji: data.emoji,
               name: data.name,
@@ -162,6 +183,7 @@ export function RunProvider({ children }: { children: ReactNode }) {
             inst.terminal += data.text;
             break;
           case "done": {
+            inst.pendingInput = null;
             inst.steps = inst.steps.map((s) => (s.status === "running" ? { ...s, status: "done" } : s));
             const hasContent = inst.steps.some((s) => s.content.trim());
             if (data?.code && data.code !== 0 && !hasContent) {
@@ -250,6 +272,21 @@ export function RunProvider({ children }: { children: ReactNode }) {
     [start],
   );
 
+  const submitInput = useCallback(
+    (id: string, text: string) => {
+      const inst = runsRef.current.get(id);
+      if (!inst?.runId || !inst.pendingInput) return;
+      // 乐观清除等待态；引擎收到输入后会继续推进
+      inst.pendingInput = null;
+      touch();
+      api.runInput(inst.runId, text).catch((e) => {
+        inst.error = e?.message || String(e);
+        touch();
+      });
+    },
+    [touch],
+  );
+
   const value: RunManagerValue = {
     runs: Array.from(runsRef.current.values()),
     openId: openRef.current,
@@ -258,6 +295,7 @@ export function RunProvider({ children }: { children: ReactNode }) {
     remove,
     open,
     rerunWithFeedback,
+    submitInput,
   };
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>;

--- a/website/src/components/studio/RunViewer.tsx
+++ b/website/src/components/studio/RunViewer.tsx
@@ -1,14 +1,14 @@
-import { Check, Copy, Download, Loader2, Minus, Square, Terminal, X } from "lucide-react";
+import { Check, Copy, Download, Loader2, MessageSquare, Minus, Square, Terminal, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useCopy } from "@/components/ui/copy-button";
 import { StepList } from "./StepList";
-import { useRunManager } from "./RunManager";
+import { useRunManager, type PendingInput } from "./RunManager";
 import { downloadText, safeFilename } from "@/lib/download";
 import { cn } from "@/lib/utils";
 
 export function RunViewer({ onViewHistory }: { onViewHistory?: () => void }) {
-  const { runs, openId, open, stop, rerunWithFeedback } = useRunManager();
+  const { runs, openId, open, stop, rerunWithFeedback, submitInput } = useRunManager();
   const run = runs.find((r) => r.id === openId) || null;
   const [showTerminal, setShowTerminal] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -109,6 +109,9 @@ export function RunViewer({ onViewHistory }: { onViewHistory?: () => void }) {
               }
             />
           )}
+          {run.pendingInput && running && (
+            <RunInputBox pending={run.pendingInput} onSubmit={(text) => submitInput(run.id, text)} />
+          )}
           {run.summary && !running && (
             <div className="mt-4 rounded-xl border border-primary/30 bg-primary/[0.06] px-4 py-3 text-sm font-medium text-primary">
               {run.summary}
@@ -151,6 +154,54 @@ export function RunViewer({ onViewHistory }: { onViewHistory?: () => void }) {
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+/** 运行中某步暂停等待人工输入时的弹层：human_input 给输入框，approval 给通过/驳回。 */
+function RunInputBox({ pending, onSubmit }: { pending: PendingInput; onSubmit: (text: string) => void }) {
+  const [text, setText] = useState("");
+  const isApproval = pending.type === "approval";
+
+  const submit = (val?: string) => {
+    const v = val ?? text;
+    if (!isApproval && !v.trim()) return;
+    onSubmit(v);
+    setText("");
+  };
+
+  return (
+    <div className="mt-4 rounded-xl border border-primary/45 bg-primary/[0.06] px-4 py-3 shadow-sm">
+      <div className="mb-1.5 flex items-center gap-2 text-sm font-semibold text-primary">
+        <MessageSquare className="size-4" />
+        {isApproval ? "需要你确认才能继续" : "需要你的输入才能继续"}
+      </div>
+      <p className="mb-2.5 whitespace-pre-wrap text-sm text-foreground">{pending.prompt}</p>
+      {isApproval ? (
+        <div className="flex gap-2">
+          <Button size="sm" onClick={() => submit("yes")}>通过，继续</Button>
+          <Button size="sm" variant="outline" onClick={() => submit("no")}>驳回</Button>
+        </div>
+      ) : (
+        <>
+          <textarea
+            autoFocus
+            rows={2}
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={(e) => {
+              if ((e.metaKey || e.ctrlKey) && e.key === "Enter") submit();
+            }}
+            placeholder="输入后提交，工作流带着它继续往下跑…（⌘/Ctrl+Enter 提交）"
+            className="w-full resize-none rounded-lg border border-border/70 bg-background px-3 py-2 text-sm outline-none focus:border-primary/60"
+          />
+          <div className="mt-2 flex justify-end">
+            <Button size="sm" disabled={!text.trim()} onClick={() => submit()}>
+              提交并继续
+            </Button>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/website/src/lib/studio.ts
+++ b/website/src/lib/studio.ts
@@ -164,6 +164,9 @@ export const api = {
   run: (id: string) => getJSON<RunSummary>(`/runs/${encodeURIComponent(id)}`),
   compose: (body: { description: string; roles: string[]; name?: string; provider?: string }) =>
     postJSON<ComposeResult>("/compose", body),
+  // 把人工输入写回正在等待的运行（human_input / approval 节点暂停时）
+  runInput: (runId: string, text: string) =>
+    postJSON<{ ok: boolean }>("/run-input", { runId, text }),
 };
 
 /** Parse a Server-Sent-Events stream coming from a POST response body. */


### PR DESCRIPTION
## 背景

用户反馈「跑的时候无法干预，像抽卡」的**最后一块**。

- `--feedback`（#22）：跑完返工
- `human_input`（#23）：CLI 中途输入
- **本 PR**：把 `human_input` / `approval` 接到网页 Studio——之前这俩节点在网页里会**一直挂起**（server 从不写子进程 stdin），现在跑到该步会暂停、弹框，输入写回引擎继续。

## 怎么work的

```
引擎(子进程)                     server                        前端
human_input 暂停
  └ AO_WEB_INPUT=1 → stdout
    __AO_INPUT_REQUEST__{json}  ─→ 解析 → SSE await-input ─→ 弹 RunInputBox
                                                                  │用户输入
  readline 读到 ←─ child.stdin ←─ POST /api/run-input  ←─────────┘
继续往下跑
```

- **executor**：`AO_WEB_INPUT=1` 时 `handleHumanInput`/`handleApproval` 发机器标记到 stdout（CLI 无此 env，行为不变）
- **server**：`runId` 注册表 + 标记→`await-input` 事件 + 新增 `POST /api/run-input` 写回对应子进程 stdin；spawn 注入 `AO_WEB_INPUT=1`
- **前端**：RunManager 跟踪 `runId`/`pendingInput` + `submitInput`；RunViewer 弹 `RunInputBox`（human_input 输入框 / approval 通过·驳回）

## 验证

- 全量 `npm test` 绿（含 51 模板门禁；executor 改动不影响 CLI/e2e）
- **headless e2e**：脚本 POST /api/run（SSE）→ 收到 `await-input{type,stepId,prompt,runId}` → POST /api/run-input → 运行完成 code 0、该步产出==所发文本（human_input + approval 均验证）
- website `npm run build`、`node -c web/server.js` 通过

## 未覆盖

浏览器里真人点击的视觉验证（需手动开 Studio）。逻辑链路已 headless 全程验证。