### PR TITLE
feat(desktop): 桌面安装包自动发布 Action + 官网下载入口

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,0 +1,77 @@
+name: Release Desktop App
+
+# 手动触发：在 Actions 页面点 "Run workflow"，填一个 tag（如 desktop-v0.1.1）。
+# 三平台(mac arm64 / win / linux)各自构建桌面安装包并上传到对应 GitHub Release。
+# 当前为未签名版（desktop/package.json 里 mac.identity=null）。要启用 mac 签名/公证：
+#   1) 去掉 desktop/package.json 的 "identity": null
+#   2) 在仓库 Secrets 加 CSC_LINK / CSC_KEY_PASSWORD / APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD / APPLE_TEAM_ID
+#   下面的步骤已透传这些 env，有就自动签、没有就出未签名版。
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. desktop-v0.1.1)"
+        required: true
+        default: "desktop-v0.1.1"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            builder_flag: "--mac"
+          - os: windows-latest
+            builder_flag: "--win"
+          - os: ubuntu-latest
+            builder_flag: "--linux"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # 引擎 + 官网 Studio（桌面 App 通过 extraResources 打包 ../dist 与 ../website/dist）
+      - name: Install root deps & build engine
+        run: |
+          npm ci
+          npm run build
+      - name: Build Studio (website/dist)
+        run: npm run build:studio
+
+      - name: Install desktop deps
+        working-directory: desktop
+        run: npm ci
+
+      - name: Build desktop installer
+        working-directory: desktop
+        run: npx electron-builder ${{ matrix.builder_flag }} --publish never
+        env:
+          # 有证书/公证 Secrets 时 electron-builder 自动签名+公证；没有就出未签名版
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag }}
+          name: ${{ inputs.tag }}
+          draft: false
+          fail_on_unmatched_files: false
+          files: |
+            desktop/release/*.dmg
+            desktop/release/*.dmg.blockmap
+            desktop/release/*.exe
+            desktop/release/*.exe.blockmap
+            desktop/release/*.AppImage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/website/index.html
+++ b/website/index.html
@@ -14,11 +14,12 @@
     />
     <meta name="theme-color" content="#0b0e14" />
     <meta name="color-scheme" content="light dark" />
+    <link rel="canonical" href="https://ao.aiolaola.com/" />
 
     <meta property="og:title" content="Agency Orchestrator — 一句话，让多个 AI 角色自动协作" />
     <meta property="og:description" content="一句话 → AI 自动拆解任务 → 从 211 个角色中匹配 → 按 DAG 并行执行 → 输出完整方案。" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://github.com/jnMetaCode/agency-orchestrator" />
+    <meta property="og:url" content="https://ao.aiolaola.com/" />
     <meta name="twitter:card" content="summary_large_image" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/website/src/content/docs.ts
+++ b/website/src/content/docs.ts
@@ -82,6 +82,13 @@ export const docGroups: DocGroup[] = [
               en: "No key needed to start: AO supports 7 key-free paths such as the claude-code CLI, gemini-cli, and local Ollama. Install the CLI or local model, then point to it with `--provider`.",
             },
           },
+          {
+            heading: { zh: "不想用命令行？下载桌面客户端", en: "Prefer no terminal? Download the desktop app" },
+            body: {
+              zh: "不熟悉命令行可以直接下载**桌面客户端**（原生 App，免装 Node）：[**前往下载 →**](https://github.com/jnMetaCode/agency-orchestrator/releases/latest)（macOS / Windows / Linux）。\n\n> macOS 提示：当前为未签名版，首次打开请**右键 →「打开」**绕过 Gatekeeper 提示。桌面端把网页 Studio 包成原生应用，体验和 `ao web` 一致，key 同样只存本机。",
+              en: "Not comfortable with the command line? Just download the **desktop app** (native, no Node needed): [**Download →**](https://github.com/jnMetaCode/agency-orchestrator/releases/latest) (macOS / Windows / Linux).\n\n> macOS note: the current build is unsigned — on first open, **right-click → Open** to bypass Gatekeeper. The desktop app wraps the web Studio natively; same experience as `ao web`, and your key still stays on your machine.",
+            },
+          },
         ],
       },
       {

--- a/website/src/lib/site.ts
+++ b/website/src/lib/site.ts
@@ -8,6 +8,7 @@ export const SITE = {
   changelog: "https://github.com/jnMetaCode/agency-orchestrator/blob/main/CHANGELOG.md",
   license: "https://github.com/jnMetaCode/agency-orchestrator/blob/main/LICENSE",
   evalFindings: "https://github.com/jnMetaCode/agency-orchestrator/blob/main/EVAL_FINDINGS.md",
+  releases: "https://github.com/jnMetaCode/agency-orchestrator/releases/latest",
   install: "npm i -g agency-orchestrator",
   sponsorEmail: "jnMetaCode@qq.com",
   sponsorContact: "mailto:jnMetaCode@qq.com?subject=Sponsorship%20-%20agency-agents",


### PR DESCRIPTION
新增手动触发的 release-desktop.yml(三平台构建+发 Release，未签名即可，留好签名 Secrets 透传)，文档安装页加「下载桌面客户端」入口(指向 releases/latest)。