### PR TITLE
feat(studio): 专家详情一键复制完整提示词

### DIFF
--- a/website/src/components/studio/RoleDetail.tsx
+++ b/website/src/components/studio/RoleDetail.tsx
@@ -1,4 +1,4 @@
-import { Loader2, MessageSquare, X } from "lucide-react";
+import { Check, Copy, Loader2, MessageSquare, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useLanguage } from "@/i18n/LanguageProvider";
@@ -6,6 +6,27 @@ import { api, type Role } from "@/lib/studio";
 import { Markdown } from "./Markdown";
 import { RoleAvatar } from "./RoleAvatar";
 import type { RunRequest } from "./RunManager";
+
+async function copyText(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    try {
+      const ta = document.createElement("textarea");
+      ta.value = text;
+      ta.style.position = "fixed";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      const ok = document.execCommand("copy");
+      document.body.removeChild(ta);
+      return ok;
+    } catch {
+      return false;
+    }
+  }
+}
 
 export function RoleDetail({
   role,
@@ -23,6 +44,14 @@ export function RoleDetail({
   const [full, setFull] = useState<Role | null>(role.content ? role : null);
   const [loading, setLoading] = useState(!role.content);
   const [task, setTask] = useState("");
+  const [copied, setCopied] = useState<"ok" | "fail" | null>(null);
+
+  const copyPrompt = async () => {
+    if (!full?.content) return;
+    const ok = await copyText(full.content);
+    setCopied(ok ? "ok" : "fail");
+    setTimeout(() => setCopied(null), 1800);
+  };
 
   useEffect(() => {
     if (role.content) return;
@@ -66,7 +95,26 @@ export function RoleDetail({
                 <Loader2 className="size-4 animate-spin" /> {t.studio.roles.loadingAbilities}
               </p>
             ) : full?.content ? (
-              <Markdown>{full.content}</Markdown>
+              <>
+                <div className="mb-2 flex justify-end">
+                  <button
+                    type="button"
+                    onClick={copyPrompt}
+                    className={
+                      "inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1 text-xs font-medium transition-colors " +
+                      (copied === "ok"
+                        ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-500"
+                        : copied === "fail"
+                          ? "border-red-500/40 bg-red-500/10 text-red-500"
+                          : "border-border/70 text-muted-foreground hover:border-primary/40 hover:text-foreground")
+                    }
+                  >
+                    {copied === "ok" ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+                    {copied === "ok" ? t.studio.roles.copied : copied === "fail" ? t.studio.roles.copyFailed : t.studio.roles.copyPrompt}
+                  </button>
+                </div>
+                <Markdown>{full.content}</Markdown>
+              </>
             ) : (
               <p className="text-sm text-muted-foreground">{t.studio.roles.noMoreInfo}</p>
             )}

--- a/website/src/i18n/translations.ts
+++ b/website/src/i18n/translations.ts
@@ -225,6 +225,9 @@ const zh = {
       askPrefix: "想问 ",
       askSuffix: " 什么？",
       chat: "对话",
+      copyPrompt: "复制提示词",
+      copied: "已复制",
+      copyFailed: "复制失败",
     },
     usage: {
       loadFailed: "加载失败：",
@@ -656,6 +659,9 @@ const en: typeof zh = {
       askPrefix: "Ask ",
       askSuffix: " anything…",
       chat: "Chat",
+      copyPrompt: "Copy prompt",
+      copied: "Copied",
+      copyFailed: "Copy failed",
     },
     usage: {
       loadFailed: "Failed to load: ",


### PR DESCRIPTION
Studio 专家详情(RoleDetail)本就加载了完整系统提示词,只缺复制入口。补上「复制提示词」按钮:

- 复制按钮在提示词区右上,带「已复制 / 复制失败」反馈,execCommand 兜底(Safari 可用)
- `ao web` 与桌面版的 Studio(都由 web/server.js serve website/dist)同样生效
- i18n zh+en

> 注:已部署的 desktop-v0.2.0 仍是旧 Studio,要让桌面版用户也用上需重新出一版桌面包。