### PR TITLE
build(desktop): 发布始终 make_latest,保住官网下载入口

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -83,6 +83,9 @@ jobs:
           tag_name: ${{ inputs.tag }}
           name: ${{ inputs.tag }}
           draft: false
+          # 桌面包始终标记为 latest：官网「下载桌面客户端」走 /releases/latest，
+          # 引擎(npm)版本另发 v* release 时用 --latest=false，避免抢走下载入口。
+          make_latest: "true"
           fail_on_unmatched_files: false
           body: |
             ## 安装 / Install


### PR DESCRIPTION
v0.7.0 引擎 release 把 GitHub 'Latest' 从桌面包抢走,导致官网 /releases/latest 下载链接指向无安装包的版本。

- 桌面发布固定 `make_latest: true`,每次出包都收回 latest
- 引擎(npm)版本另发 `v*` release 时记得 `--latest=false`
- 已手动把 desktop-v0.2.1 重新标记为 latest,下载链接已恢复(4 个安装包)