### PR TITLE
fix(desktop): 桌面端找不到本地 CLI provider，重建 PATH (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **桌面端连不上本地 CLI（claude/codex/gemini）**（#41）：从 Finder/Dock 启动的 GUI 应用只继承 launchd 的精简 PATH（`/usr/bin:/bin:...`），找不到装在 homebrew / `~/.local/bin` / npm-global 里的 CLI provider 二进制，表现为「找不到 claude / 连不上本地 cli」。桌面壳现在在拉起引擎前重建可用 PATH（登录 shell 的 PATH + 常见 bin 目录），子进程继承之；终端里 `ao run` 不受影响。
+
 ## [0.7.5] - 2026-06-17
 
 ### Fixed

--- a/desktop/main.cjs
+++ b/desktop/main.cjs
@@ -3,14 +3,56 @@
 // Node (ELECTRON_RUN_AS_NODE), then opens a native window onto the local UI.
 // No system Node install required.
 const { app, BrowserWindow, shell } = require("electron");
-const { spawn } = require("node:child_process");
+const { spawn, execFileSync } = require("node:child_process");
 const path = require("node:path");
+const os = require("node:os");
 const http = require("node:http");
 
 const ROOT = app.isPackaged ? path.join(process.resourcesPath, "app") : path.resolve(__dirname, "..");
 const PORT = process.env.AO_DESKTOP_PORT || "8799";
 const BASE = `http://127.0.0.1:${PORT}/`;
 let backend = null;
+
+// GUI apps launched from Finder/Dock inherit the minimal launchd PATH
+// (/usr/bin:/bin:/usr/sbin:/sbin), NOT the user's shell PATH. So CLI providers
+// installed in homebrew / ~/.local/bin / npm-global (claude, codex, gemini…) are
+// invisible to the spawned engine → "找不到 claude / 连不上本地 CLI" (issue #41).
+// Rebuild a usable PATH: the login shell's PATH (best effort) + common bin dirs.
+function resolvedPath() {
+  const parts = [];
+  if (process.platform !== "win32") {
+    // Ask the login shell for its PATH (covers nvm/asdf/custom installs).
+    try {
+      const shellBin = process.env.SHELL || "/bin/zsh";
+      const out = execFileSync(shellBin, ["-lic", "printf %s \"$PATH\""], {
+        timeout: 4000,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+      if (out) parts.push(out);
+    } catch {
+      /* shell probe failed — fall back to curated dirs below */
+    }
+    const home = os.homedir();
+    parts.push(
+      "/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin",
+      path.join(home, ".local/bin"),
+      path.join(home, ".npm-global/bin"),
+      path.join(home, ".bun/bin"),
+      path.join(home, ".deno/bin"),
+      path.join(home, ".cargo/bin"),
+    );
+  }
+  if (process.env.PATH) parts.push(process.env.PATH);
+  // de-dupe, preserve order, drop empties
+  const seen = new Set();
+  const sep = process.platform === "win32" ? ";" : ":";
+  return parts
+    .join(sep)
+    .split(sep)
+    .filter((p) => p && !seen.has(p) && seen.add(p))
+    .join(sep);
+}
 
 function startBackend() {
   const serverPath = path.join(ROOT, "web", "server.js");
@@ -21,6 +63,7 @@ function startBackend() {
       ELECTRON_RUN_AS_NODE: "1", // run the backend (and its engine children) as plain Node
       AO_NODE: process.execPath, // engine binary the server should spawn
       AO_DATA_DIR: app.getPath("userData"), // writable dir for outputs / keys (bundle is read-only)
+      PATH: resolvedPath(), // so CLI providers (claude/codex/gemini) are found (issue #41)
       PORT,
       HOST: "127.0.0.1",
     },


### PR DESCRIPTION
## 问题（#41）

桌面端「连不上本地的 claude / codex CLI」。

## 根因

- `desktop/main.cjs` 用 `env: {...process.env}` 拉起引擎，`src/connectors/claude-code.ts` 用 `spawn("claude")` 靠 PATH 找二进制
- macOS 上从 Finder/Dock 启动的 GUI 只继承 launchd 精简 PATH（`/usr/bin:/bin:/usr/sbin:/sbin`），**不含**用户 shell 的 PATH——装在 `~/.local/bin`、`/opt/homebrew/bin`、npm-global 里的 `claude/codex/gemini` 全找不到 → `ENOENT` → 「找不到 claude」
- 终端里 `ao run` 正常，只有桌面端中招

## 修复

桌面壳在拉起引擎前重建可用 PATH = 登录 shell 的 PATH（best-effort，带超时）+ 常见 bin 目录，子进程继承。已用模拟 launchd PATH 验证修复后 `claude`/`codex` 都能找到。

> #41 里另有「agents 占空间 / 不能改安装路径 / 文档不清」的次要诉求，属打包/文档层面，本 PR 不含，留作单独 issue。

Fixes #41