### PR TITLE
fix(studio): 默认语言跟随环境 + APINEBULA 缺 key 提示

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Studio 语言显示**：网页端 / 桌面端的 Studio 此前可能默认英文且**没有切换入口**——用户被困在英文界面。现在 Studio 头部加了中/英一键切换；桌面端按操作系统语言（`app.getLocale()`）选首启语言、`ao web` 按 CLI 界面语言（`--lang`/`AO_LANG`/`LANG`）带上 `?lang=`，用户切换后由 localStorage 记住。语言判定优先级：URL 路径 `/en` > 用户已切换的持久化选择 > launcher 的 `?lang=` > 浏览器语言。
+
 ## [0.7.5] - 2026-06-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - **Studio 语言显示**：网页端 / 桌面端的 Studio 此前可能默认英文且**没有切换入口**——用户被困在英文界面。现在 Studio 头部加了中/英一键切换；桌面端按操作系统语言（`app.getLocale()`）选首启语言、`ao web` 按 CLI 界面语言（`--lang`/`AO_LANG`/`LANG`）带上 `?lang=`，用户切换后由 localStorage 记住。语言判定优先级：URL 路径 `/en` > 用户已切换的持久化选择 > launcher 的 `?lang=` > 浏览器语言。
+- **Studio 默认 provider 缺 key 不提示**：默认 provider 改成 APINEBULA 后，它没被加进 Studio 的 `KEYED` 列表，导致新用户没填 key 时**不弹「需要配置 key」提示**、直接运行才报认证错。已补上。
 
 ## [0.7.5] - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## [Unreleased]
 
 ### Fixed
-- **Studio 语言显示**：网页端 / 桌面端的 Studio 此前可能默认英文且**没有切换入口**——用户被困在英文界面。现在 Studio 头部加了中/英一键切换；桌面端按操作系统语言（`app.getLocale()`）选首启语言、`ao web` 按 CLI 界面语言（`--lang`/`AO_LANG`/`LANG`）带上 `?lang=`，用户切换后由 localStorage 记住。语言判定优先级：URL 路径 `/en` > 用户已切换的持久化选择 > launcher 的 `?lang=` > 浏览器语言。
+- **Studio 默认语言不跟随环境**：导航栏本来就有中/英切换，但**首启默认语言**走 `navigator.language`，桌面端 Electron 常判成英文 → 中文用户一进来看到英文。现在桌面端按操作系统语言（`app.getLocale()`）、`ao web` 按 CLI 界面语言（`--lang`/`AO_LANG`/`LANG`）带上 `?lang=` 决定首启语言；用户在导航栏切换后由 localStorage 记住。判定优先级：URL 路径 `/en` > 用户已切换的持久化选择 > launcher 的 `?lang=` > 浏览器语言。
 - **Studio 默认 provider 缺 key 不提示**：默认 provider 改成 APINEBULA 后，它没被加进 Studio 的 `KEYED` 列表，导致新用户没填 key 时**不弹「需要配置 key」提示**、直接运行才报认证错。已补上。
 
 ## [0.7.5] - 2026-06-17

--- a/desktop/main.cjs
+++ b/desktop/main.cjs
@@ -70,7 +70,9 @@ function createWindow() {
     shell.openExternal(url);
     return { action: "deny" };
   });
-  win.loadURL(`${BASE}studio`);
+  // 按操作系统语言给 Studio 一个首启默认语言（用户在界面里切换后由 localStorage 记住）。
+  const lang = String(app.getLocale() || "").toLowerCase().startsWith("zh") ? "zh" : "en";
+  win.loadURL(`${BASE}studio?lang=${lang}`);
 }
 
 app.whenReady().then(async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -485,7 +485,8 @@ async function handleWeb(): Promise<void> {
     env: { ...process.env, PORT: String(port), HOST: host },
   });
 
-  if (!noOpen) setTimeout(() => openBrowser(url), 1500);
+  // 让 Studio 默认跟随 CLI 的界面语言（用户在界面里切换后由 localStorage 记住）
+  if (!noOpen) setTimeout(() => openBrowser(`${url}/?lang=${detectLang()}`), 1500);
 
   const stop = () => { try { child.kill('SIGINT'); } catch { /* noop */ } };
   process.on('SIGINT', stop);

--- a/website/src/i18n/LanguageProvider.tsx
+++ b/website/src/i18n/LanguageProvider.tsx
@@ -13,10 +13,16 @@ const LanguageContext = createContext<LanguageContextValue | null>(null);
 
 function detectLang(): Language {
   if (typeof window === "undefined") return "zh";
+  // 1. URL path segment (public site /en routes)
   const seg = window.location.pathname.split("/").filter(Boolean)[0];
   if (LANGUAGES.includes(seg as Language)) return seg as Language;
+  // 2. 用户显式切换过 → 持久化优先（即使下面 launcher 传了 ?lang= 也尊重用户选择）
   const stored = window.localStorage.getItem("ao-lang");
   if (LANGUAGES.includes(stored as Language)) return stored as Language;
+  // 3. launcher 提示（桌面端 / `ao web` 按其语言带上 ?lang=zh|en）
+  const qp = new URLSearchParams(window.location.search).get("lang");
+  if (LANGUAGES.includes(qp as Language)) return qp as Language;
+  // 4. 浏览器语言兜底
   return navigator.language.toLowerCase().startsWith("zh") ? "zh" : "en";
 }
 

--- a/website/src/pages/Studio.tsx
+++ b/website/src/pages/Studio.tsx
@@ -1,4 +1,4 @@
-import { BarChart3, Boxes, Download, History, KeyRound, Plug, TriangleAlert, Users } from "lucide-react";
+import { BarChart3, Boxes, Download, History, KeyRound, Languages, Plug, TriangleAlert, Users } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { SiteFooter } from "@/components/layout/SiteFooter";
@@ -34,7 +34,7 @@ const TAB_META: { id: Tab; icon: typeof Users }[] = [
 ];
 
 function StudioInner() {
-  const { t } = useLanguage();
+  const { t, lang, toggle } = useLanguage();
   const { status, version } = useBackend();
   const TABS = TAB_META.map((tb) => ({
     ...tb,
@@ -125,6 +125,10 @@ function StudioInner() {
                 {status === "online" ? t.studio.shell.statusOnline : status === "offline" ? t.studio.shell.statusOffline : t.studio.shell.statusChecking}
               </span>
               <ProviderSelect value={provider} onChange={setProvider} />
+              <Button size="sm" variant="ghost" onClick={toggle} title={lang === "zh" ? "Switch to English" : "切换到中文"}>
+                <Languages className="size-4" />
+                <span className="hidden sm:inline">{lang === "zh" ? "EN" : "中文"}</span>
+              </Button>
               <Button size="sm" variant="outline" onClick={() => setTab("providers")}>
                 <KeyRound className="size-4" />
                 <span className="hidden sm:inline">{t.studio.shell.keys}</span>

--- a/website/src/pages/Studio.tsx
+++ b/website/src/pages/Studio.tsx
@@ -21,7 +21,9 @@ import { cn } from "@/lib/utils";
 // recharts(~390kB)只在用量 tab 用 → 懒加载，避免拖累 Studio 首屏与演示模式
 const UsagePanel = lazy(() => import("@/components/studio/UsagePanel").then((m) => ({ default: m.UsagePanel })));
 
-const KEYED = ["deepseek", "compshare", "openai", "claude"];
+// 需要 API key 的 provider。apinebula 是当前默认 provider，必须在列——否则新用户没填 key 时
+// 不会弹「需要配置 key」提示，直接运行才报认证错（commit 61e84a6 改默认后遗漏）。
+const KEYED = ["apinebula", "deepseek", "compshare", "openai", "claude"];
 
 type Tab = "roles" | "workflows" | "runs" | "usage" | "providers";
 

--- a/website/src/pages/Studio.tsx
+++ b/website/src/pages/Studio.tsx
@@ -1,4 +1,4 @@
-import { BarChart3, Boxes, Download, History, KeyRound, Languages, Plug, TriangleAlert, Users } from "lucide-react";
+import { BarChart3, Boxes, Download, History, KeyRound, Plug, TriangleAlert, Users } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { SiteFooter } from "@/components/layout/SiteFooter";
@@ -36,7 +36,7 @@ const TAB_META: { id: Tab; icon: typeof Users }[] = [
 ];
 
 function StudioInner() {
-  const { t, lang, toggle } = useLanguage();
+  const { t } = useLanguage();
   const { status, version } = useBackend();
   const TABS = TAB_META.map((tb) => ({
     ...tb,
@@ -127,10 +127,6 @@ function StudioInner() {
                 {status === "online" ? t.studio.shell.statusOnline : status === "offline" ? t.studio.shell.statusOffline : t.studio.shell.statusChecking}
               </span>
               <ProviderSelect value={provider} onChange={setProvider} />
-              <Button size="sm" variant="ghost" onClick={toggle} title={lang === "zh" ? "Switch to English" : "切换到中文"}>
-                <Languages className="size-4" />
-                <span className="hidden sm:inline">{lang === "zh" ? "EN" : "中文"}</span>
-              </Button>
               <Button size="sm" variant="outline" onClick={() => setTab("providers")}>
                 <KeyRound className="size-4" />
                 <span className="hidden sm:inline">{t.studio.shell.keys}</span>


### PR DESCRIPTION
修两个「Studio 默认显示不对」的问题。**导航栏本来就有中/英切换**,所以这里不加切换按钮,只修「默认值」。

## 1. 首启默认语言不跟随环境
导航栏(SiteNavbar)一直有中/英切换,但**首启默认语言**走 `navigator.language` → 桌面端 Electron 常判成英文,中文用户一进来看到英文。
- 桌面端按操作系统语言 `app.getLocale()` 带 `?lang=`
- `ao web` 按 CLI 界面语言(`--lang`/`AO_LANG`/`LANG`)带 `?lang=`
- `detectLang` 支持 `?lang=`,优先级:`/en` 路径 > 用户已切换的持久化(localStorage) > launcher `?lang=` > 浏览器语言

## 2. 默认 provider(APINEBULA)缺 key 不提示
默认 provider 从 DeepSeek 改成 APINEBULA(commit 61e84a6)后,**漏了把 apinebula 加进 Studio 的 `KEYED` 列表** → 新用户没填 key 时不弹「需要配置 key」提示,直接运行才报认证错。已补上。

## 测试(真实)
- `detectLang` 6 个优先级场景全过;真实 `ao web` 启动 `/studio?lang=zh` HTTP 200
- 网页 + 桌面构建通过