### PR TITLE
fix(studio): 演示模式切 tab 不响应 + tab 文案缺失防御

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **Studio 演示模式下切 tab 不响应**：引擎离线 / 公开演示站（无后端）时，「角色组队 / 工作流 / 提示词 / 运行历史 / 用量」点了内容都不变（一律显示角色 demo），看起来像卡死。现在演示模式也**按 tab 切换内容**（提示词→Prompt Lab 演示、角色→角色 demo、其余→「需本地引擎」提示 + 安装入口）。另加防御：任一 tab 文案缺失也不再让整个 Studio 渲染崩溃。
 - **Azure OpenAI 兼容**（#38）：Azure 的 gpt 模型只认 `max_completion_tokens`（不认 `max_tokens`），且用 `api-key` header 鉴权。OpenAI 兼容连接器现在检测到 `base_url` 含 `azure` 时自动切换；非 Azure 的 OpenAI o 系列推理模型可用 `AO_OPENAI_TOKENS_PARAM=max_completion_tokens` 显式覆盖（含回归测试 `test/azure-compat.ts`）。
 - **`ao prompt` 文档补齐**：Prompt Lab 合入后 `ao prompt` 一直没进 `ao --help` / README / CLAUDE.md，用户无从发现；现已补上（中英）。
 

--- a/website/src/pages/Studio.tsx
+++ b/website/src/pages/Studio.tsx
@@ -38,12 +38,13 @@ const TAB_META: { id: Tab; icon: typeof Users }[] = [
 ];
 
 function StudioInner() {
-  const { t } = useLanguage();
+  const { t, lang } = useLanguage();
   const { status, version } = useBackend();
+  // 防御：任一 tab 文案缺失也不要让整个 Studio 渲染崩溃（否则所有 tab 都点不动）
   const TABS = TAB_META.map((tb) => ({
     ...tb,
-    label: t.studio.shell.tabs[tb.id].label,
-    hint: t.studio.shell.tabs[tb.id].hint,
+    label: t.studio.shell.tabs[tb.id]?.label ?? tb.id,
+    hint: t.studio.shell.tabs[tb.id]?.hint ?? "",
   }));
   const { start, open } = useRunManager();
   const [tab, setTabState] = useState<Tab>("roles");
@@ -165,8 +166,27 @@ function StudioInner() {
                   {t.studio.demo.bannerInstall}
                 </Button>
               </div>
-              <RolesPicker provider={provider} onRun={() => setInstallOpen(true)} demo onInstallPrompt={() => setInstallOpen(true)} />
-              <StudioDemo />
+              {/* 演示模式也按 tab 切换内容，否则点哪个 tab 都只显示角色 demo、看起来像卡死 */}
+              {tab === "prompt" ? (
+                <PromptLab provider={provider} demo onInstallPrompt={() => setInstallOpen(true)} />
+              ) : tab === "roles" ? (
+                <>
+                  <RolesPicker provider={provider} onRun={() => setInstallOpen(true)} demo onInstallPrompt={() => setInstallOpen(true)} />
+                  <StudioDemo />
+                </>
+              ) : (
+                <div className="py-16 text-center">
+                  <p className="mx-auto max-w-md text-sm text-muted-foreground">
+                    {lang === "en"
+                      ? "This needs the local engine. Install the desktop app or run `ao web` locally to use it."
+                      : "这个功能需要本地引擎。安装桌面端、或本地跑 `ao web` 后即可使用。"}
+                  </p>
+                  <Button className="mt-4" size="sm" onClick={() => setInstallOpen(true)}>
+                    <Download className="size-4" />
+                    {t.studio.demo.bannerInstall}
+                  </Button>
+                </div>
+              )}
             </>
           ) : tab === "roles" ? (
             <RolesPicker provider={provider} onRun={start} onGoToWorkflows={() => setTab("workflows")} />


### PR DESCRIPTION
## 现象
Studio 里点「角色组队 / 工作流 / 提示词 / 运行历史 / 用量统计」都不跳转、看似卡死(用户反馈)。

## 根因
不是新加的「提示词」功能本身的 bug,而是**演示 / 离线模式**(无后端,如公开演示站)的既有渲染逻辑:`offline ? <角色 demo> : tab===...`——离线时**无视当前 tab,一律渲染角色 demo**,所以点任何 tab 内容都不变。加了提示词 tab 后,多一个 tab 也这样,问题更明显。
- 在线 + 本地引擎时各 tab 正常切换(已核实 /api/workflows、/roles、/runs、/usage、/prompt/garden、/studio 均 200)。

## 修复
1. **演示模式也按 tab 切内容**:提示词→Prompt Lab 演示、角色→角色 demo+演示动画、其余(工作流/历史/用量)→「需本地引擎」提示卡 + 安装入口。点 tab 立刻有反馈。
2. **防御**:`t.studio.shell.tabs[id]?.label ?? id` —— 任一 tab 文案缺失也不再让整个 Studio 渲染抛错卡死(根治这一类「一个 tab 崩、全部 tab 不动」)。

## 验证
- 网页构建通过,新逻辑已进 bundle;后端 `npm test` 全绿
- 在线模式所有 tab 的后端 API + /studio 页面均 200

> 注:若是本地 `ao web`,请确保 `npm run build:studio` 重建过 `website/dist` 并硬刷新浏览器(旧缓存 bundle 也会表现为不更新)。