### PR TITLE
fix(studio): 演示模式按 tab 显示真实内容(可浏览不可运行)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## [Unreleased]
 
 ### Fixed
-- **Studio 演示模式下切 tab 不响应**：引擎离线 / 公开演示站（无后端）时，「角色组队 / 工作流 / 提示词 / 运行历史 / 用量」点了内容都不变（一律显示角色 demo），看起来像卡死。现在演示模式也**按 tab 切换内容**（提示词→Prompt Lab 演示、角色→角色 demo、其余→「需本地引擎」提示 + 安装入口）。另加防御：任一 tab 文案缺失也不再让整个 Studio 渲染崩溃。
+- **Studio 演示模式下切 tab 不响应**：引擎离线 / 公开演示站（无后端）时，各 tab 点了内容都不变（一律显示角色 demo），看起来像卡死。现在演示模式也**按 tab 显示真实内容、可浏览**——工作流展示内置模板快照、角色展示角色库、提示词展示 Prompt Lab，**只是运行类操作引导安装、不能真跑**（运行历史 / 用量本就无离线数据，给出简短说明）。另加防御：任一 tab 文案缺失也不再让整个 Studio 渲染崩溃。
 - **Azure OpenAI 兼容**（#38）：Azure 的 gpt 模型只认 `max_completion_tokens`（不认 `max_tokens`），且用 `api-key` header 鉴权。OpenAI 兼容连接器现在检测到 `base_url` 含 `azure` 时自动切换；非 Azure 的 OpenAI o 系列推理模型可用 `AO_OPENAI_TOKENS_PARAM=max_completion_tokens` 显式覆盖（含回归测试 `test/azure-compat.ts`）。
 - **`ao prompt` 文档补齐**：Prompt Lab 合入后 `ao prompt` 一直没进 `ao --help` / README / CLAUDE.md，用户无从发现；现已补上（中英）。
 

--- a/website/src/components/studio/WorkflowsPanel.tsx
+++ b/website/src/components/studio/WorkflowsPanel.tsx
@@ -86,7 +86,7 @@ function InputsDialog({ wf, provider, onClose, onRun }: { wf: Workflow; provider
   );
 }
 
-export function WorkflowsPanel({ provider, onRun }: { provider: string; onRun: (r: RunRequest) => void }) {
+export function WorkflowsPanel({ provider, onRun, demo, onInstallPrompt }: { provider: string; onRun: (r: RunRequest) => void; demo?: boolean; onInstallPrompt?: () => void }) {
   const { t, lang } = useLanguage();
   const [wfs, setWfs] = useState<Workflow[]>([]);
   const [loading, setLoading] = useState(true);
@@ -98,12 +98,20 @@ export function WorkflowsPanel({ provider, onRun }: { provider: string; onRun: (
 
   useEffect(() => {
     setLoading(true);
+    if (demo) {
+      // 演示模式：用静态模板快照，可浏览、看步骤，但运行时引导安装
+      import("@/lib/demo")
+        .then((m) => setWfs(m.demoWorkflows(lang)))
+        .catch(() => setWfs([]))
+        .finally(() => setLoading(false));
+      return;
+    }
     api
       .workflows(lang)
       .then(setWfs)
       .catch((e) => setErr(e.message))
       .finally(() => setLoading(false));
-  }, [lang]);
+  }, [lang, demo]);
 
   const filtered = useMemo(() => {
     const n = q.trim().toLowerCase();
@@ -121,6 +129,7 @@ export function WorkflowsPanel({ provider, onRun }: { provider: string; onRun: (
     });
 
   const runOne = (w: Workflow) => {
+    if (demo) return onInstallPrompt?.();
     if (w.inputs && w.inputs.length) setInputsFor(w);
     else onRun({ kind: "workflow", title: w.name, file: w.file, provider: provider || undefined, cast: w.steps });
   };
@@ -201,7 +210,7 @@ export function WorkflowsPanel({ provider, onRun }: { provider: string; onRun: (
               <button onClick={() => setPicked({})} className="text-xs text-muted-foreground hover:text-foreground">
                 {t.studio.workflows.clear}
               </button>
-              <Button onClick={() => setCompare(pickedList)}>
+              <Button onClick={() => (demo ? onInstallPrompt?.() : setCompare(pickedList))}>
                 <GitCompare className="size-4" />
                 {t.studio.workflows.compareRun}
               </Button>

--- a/website/src/lib/demo.ts
+++ b/website/src/lib/demo.ts
@@ -1,7 +1,7 @@
 // 公开站「演示模式」数据层：没有本地后端时，专家库直接读静态数据
 // （experts.json + public/prompts/*.md），可浏览 / 查看 / 复制提示词，但不能真跑。
 // experts.json(~150kB)动态加载，避免被打进 Studio 首屏 chunk（只有进演示模式才取）。
-import type { Role } from "./studio";
+import type { Role, Workflow } from "./studio";
 
 interface ExpertEntry {
   category: string;
@@ -36,4 +36,72 @@ export async function demoRoleContent(lang: "zh" | "en", category: string, id: s
   const res = await fetch(`/prompts/${lang}/${category}/${id}.md`);
   if (!res.ok) throw new Error("not found");
   return res.text();
+}
+
+// 演示模式工作流：公开站无后端，这里给一组内置模板的静态快照，可浏览 / 看步骤，但不能真跑。
+type DemoWf = { name: { zh: string; en: string }; desc: { zh: string; en: string }; steps: { role: string; name: { zh: string; en: string }; emoji: string }[] };
+const DEMO_WORKFLOWS: DemoWf[] = [
+  {
+    name: { zh: "技术博客创作", en: "Tech Blog" },
+    desc: { zh: "一句话主题 → 趋势调研 → 大纲 → 正文 → 润色，输出可发布的技术博客", en: "One topic → research → outline → draft → polish into a publishable post" },
+    steps: [
+      { role: "product/product-trend-researcher", name: { zh: "趋势研究员", en: "Trend Researcher" }, emoji: "🔬" },
+      { role: "engineering/engineering-technical-writer", name: { zh: "技术作家", en: "Tech Writer" }, emoji: "✍️" },
+      { role: "engineering/engineering-senior-developer", name: { zh: "资深开发", en: "Senior Dev" }, emoji: "💻" },
+    ],
+  },
+  {
+    name: { zh: "创业可行性分析", en: "Startup Feasibility" },
+    desc: { zh: "市场 / 用户 / 产品 / 财务多角度并行评估，输出可行性结论", en: "Parallel market / user / product / finance analysis → feasibility verdict" },
+    steps: [
+      { role: "product/product-market-researcher", name: { zh: "市场研究员", en: "Market Researcher" }, emoji: "📊" },
+      { role: "product/product-user-researcher", name: { zh: "用户研究员", en: "User Researcher" }, emoji: "🔍" },
+      { role: "finance/finance-cfo", name: { zh: "财务总监", en: "CFO" }, emoji: "💰" },
+    ],
+  },
+  {
+    name: { zh: "PR 代码审查", en: "PR Code Review" },
+    desc: { zh: "安全 / 性能 / 可读性三路并行审查 → 汇总修改建议", en: "Security / performance / readability review in parallel → consolidated feedback" },
+    steps: [
+      { role: "engineering/engineering-code-reviewer", name: { zh: "代码审查员", en: "Code Reviewer" }, emoji: "🔍" },
+      { role: "engineering/engineering-security-engineer", name: { zh: "安全工程师", en: "Security Eng" }, emoji: "🛡️" },
+    ],
+  },
+  {
+    name: { zh: "小红书爆款文案", en: "Viral Social Post" },
+    desc: { zh: "选题 → 标题 → 正文 → 标签，产出一篇可直接发的小红书笔记", en: "Topic → hook → body → tags: a ready-to-post note" },
+    steps: [
+      { role: "marketing/marketing-growth-hacker", name: { zh: "增长黑客", en: "Growth Hacker" }, emoji: "🚀" },
+      { role: "marketing/marketing-content-creator", name: { zh: "内容创作者", en: "Content Creator" }, emoji: "✍️" },
+    ],
+  },
+  {
+    name: { zh: "会议纪要整理", en: "Meeting Notes" },
+    desc: { zh: "清理 → 决策 / TODO / 争议三视角并行 → 整合成结构化纪要", en: "Clean up → decisions / TODOs / disputes → structured minutes" },
+    steps: [
+      { role: "operations/operations-chief-of-staff", name: { zh: "幕僚长", en: "Chief of Staff" }, emoji: "📋" },
+      { role: "product/product-manager", name: { zh: "产品经理", en: "Product Manager" }, emoji: "🧭" },
+    ],
+  },
+  {
+    name: { zh: "OKR 拆解", en: "OKR Breakdown" },
+    desc: { zh: "现状分析 → 季度 KR → 行动方案 → 完整 OKR 文档", en: "Status → quarterly KRs → action plan → full OKR doc" },
+    steps: [
+      { role: "operations/operations-chief-of-staff", name: { zh: "战略幕僚", en: "Strategist" }, emoji: "🎯" },
+      { role: "product/product-manager", name: { zh: "产品经理", en: "Product Manager" }, emoji: "🧭" },
+    ],
+  },
+];
+
+/** 演示模式工作流列表(静态快照，标 private=false，file 用 demo:// 占位，不可真跑)。 */
+export function demoWorkflows(lang: "zh" | "en"): Workflow[] {
+  return DEMO_WORKFLOWS.map((w, i) => ({
+    file: `demo://${i}`,
+    filename: `${w.name.en.toLowerCase().replace(/\s+/g, "-")}.yaml`,
+    name: w.name[lang],
+    description: w.desc[lang],
+    inputs: [],
+    steps: w.steps.map((s, j) => ({ id: `step_${j + 1}`, role: s.role, name: s.name[lang], emoji: s.emoji })),
+    private: false,
+  }));
 }

--- a/website/src/pages/Studio.tsx
+++ b/website/src/pages/Studio.tsx
@@ -166,26 +166,22 @@ function StudioInner() {
                   {t.studio.demo.bannerInstall}
                 </Button>
               </div>
-              {/* 演示模式也按 tab 切换内容，否则点哪个 tab 都只显示角色 demo、看起来像卡死 */}
-              {tab === "prompt" ? (
+              {/* 演示模式也按 tab 显示真实内容（可浏览，只是不能真跑）；运行类操作引导安装 */}
+              {tab === "workflows" ? (
+                <WorkflowsPanel provider={provider} onRun={start} demo onInstallPrompt={() => setInstallOpen(true)} />
+              ) : tab === "prompt" ? (
                 <PromptLab provider={provider} demo onInstallPrompt={() => setInstallOpen(true)} />
-              ) : tab === "roles" ? (
+              ) : tab === "runs" || tab === "usage" ? (
+                <p className="py-16 text-center text-sm text-muted-foreground">
+                  {lang === "en"
+                    ? "Nothing here in demo mode yet — run a workflow locally and it'll show up."
+                    : "演示模式下这里还没有数据，本地实际跑过工作流后就会出现。"}
+                </p>
+              ) : (
                 <>
                   <RolesPicker provider={provider} onRun={() => setInstallOpen(true)} demo onInstallPrompt={() => setInstallOpen(true)} />
                   <StudioDemo />
                 </>
-              ) : (
-                <div className="py-16 text-center">
-                  <p className="mx-auto max-w-md text-sm text-muted-foreground">
-                    {lang === "en"
-                      ? "This needs the local engine. Install the desktop app or run `ao web` locally to use it."
-                      : "这个功能需要本地引擎。安装桌面端、或本地跑 `ao web` 后即可使用。"}
-                  </p>
-                  <Button className="mt-4" size="sm" onClick={() => setInstallOpen(true)}>
-                    <Download className="size-4" />
-                    {t.studio.demo.bannerInstall}
-                  </Button>
-                </div>
               )}
             </>
           ) : tab === "roles" ? (


### PR DESCRIPTION
修正上一版(#49):离线/演示页点「工作流」等弹「需要本地引擎」安装墙,体验割裂。按反馈改为**演示页正常显示内容,只是不能正式运行**:
- **工作流** → 内置模板快照(可浏览、看步骤与角色),点运行/对比引导安装
- **角色** → 角色库 demo;**提示词** → Prompt Lab demo(UI 可用,动作引导安装)
- **运行历史 / 用量** → 简短说明(这两类本就需要本地实际跑过才有数据)

实现:`WorkflowsPanel` 加 `demo`/`onInstallPrompt`;`lib/demo.ts` 新增 `demoWorkflows`(6 个内置模板的双语静态快照)。网页构建通过。