### PR TITLE
chore(web): 赞助位只在赞助页显示(移出首页与 Studio)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **赞助位收敛到赞助页**：APINEBULA 旗舰赞助 / 优惠码推广此前在首页(SponsorStrip)和 Studio(StudioSponsorSlot)也展示，现仅保留在 `/sponsors` 赞助页，不再出现在首页与工作区。
+
 ### Fixed
 - **Studio 演示模式下切 tab 不响应**：引擎离线 / 公开演示站（无后端）时，各 tab 点了内容都不变（一律显示角色 demo），看起来像卡死。现在演示模式也**按 tab 显示真实内容、可浏览**——工作流展示内置模板快照、角色展示角色库、提示词展示 Prompt Lab，**只是运行类操作引导安装、不能真跑**（运行历史 / 用量本就无离线数据，给出简短说明）。另加防御：任一 tab 文案缺失也不再让整个 Studio 渲染崩溃。
 - **Azure OpenAI 兼容**（#38）：Azure 的 gpt 模型只认 `max_completion_tokens`（不认 `max_tokens`），且用 `api-key` header 鉴权。OpenAI 兼容连接器现在检测到 `base_url` 含 `azure` 时自动切换；非 Azure 的 OpenAI o 系列推理模型可用 `AO_OPENAI_TOKENS_PARAM=max_completion_tokens` 显式覆盖（含回归测试 `test/azure-compat.ts`）。

--- a/website/src/pages/Home.tsx
+++ b/website/src/pages/Home.tsx
@@ -3,7 +3,6 @@ import { FinalCta } from "@/components/home/FinalCta";
 import { Hero } from "@/components/home/Hero";
 import { OneLinerDemo } from "@/components/home/OneLinerDemo";
 import { Providers } from "@/components/home/Providers";
-import { SponsorStrip } from "@/components/home/SponsorStrip";
 import { SiteFooter } from "@/components/layout/SiteFooter";
 
 export default function Home() {
@@ -14,7 +13,6 @@ export default function Home() {
         <OneLinerDemo />
         <Features />
         <Providers />
-        <SponsorStrip />
         <FinalCta />
       </main>
       <SiteFooter />

--- a/website/src/pages/Studio.tsx
+++ b/website/src/pages/Studio.tsx
@@ -11,7 +11,6 @@ import { RunProvider, useRunManager } from "@/components/studio/RunManager";
 import { RunViewer } from "@/components/studio/RunViewer";
 import { RunsPanel } from "@/components/studio/RunsPanel";
 import { StudioDemo } from "@/components/studio/StudioDemo";
-import { StudioSponsorSlot } from "@/components/studio/StudioSponsorSlot";
 import { InstallPrompt } from "@/components/studio/InstallPrompt";
 import { WorkflowsPanel } from "@/components/studio/WorkflowsPanel";
 import { useBackend } from "@/components/studio/useBackend";
@@ -210,7 +209,6 @@ function StudioInner() {
       />
       <RunDock />
       {installOpen && <InstallPrompt onClose={() => setInstallOpen(false)} />}
-      <StudioSponsorSlot />
       <SiteFooter />
     </>
   );


### PR DESCRIPTION
APINEBULA 旗舰赞助 / 优惠码推广此前在**首页**(SponsorStrip)和 **Studio 工作区**(StudioSponsorSlot)也展示,显得到处都是。按反馈收敛:**只在 `/sponsors` 赞助页保留**,首页与 Studio 移除。组件文件保留(未删),想恢复轻量首页致谢一行即可加回。