### PR TITLE
fix(studio): 演示页展示全部内置工作流 + 运行历史/用量区分

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **赞助位收敛到赞助页**：APINEBULA 旗舰赞助 / 优惠码推广此前在首页(SponsorStrip)和 Studio(StudioSponsorSlot)也展示，现仅保留在 `/sponsors` 赞助页，不再出现在首页与工作区。
 
 ### Fixed
+- **演示页工作流太少 / 运行历史与用量「显示同一个」**：演示模式工作流改为读取**全部内置模板的静态快照**(19 个中文 / 10 个英文,由 `gen-workflows.mjs` 生成),不再只有手写几个;运行历史与用量两个 tab 给出**各自独立**的说明文案,不再雷同看着像没切换。
 - **Studio 演示模式下切 tab 不响应**：引擎离线 / 公开演示站（无后端）时，各 tab 点了内容都不变（一律显示角色 demo），看起来像卡死。现在演示模式也**按 tab 显示真实内容、可浏览**——工作流展示内置模板快照、角色展示角色库、提示词展示 Prompt Lab，**只是运行类操作引导安装、不能真跑**（运行历史 / 用量本就无离线数据，给出简短说明）。另加防御：任一 tab 文案缺失也不再让整个 Studio 渲染崩溃。
 - **Azure OpenAI 兼容**（#38）：Azure 的 gpt 模型只认 `max_completion_tokens`（不认 `max_tokens`），且用 `api-key` header 鉴权。OpenAI 兼容连接器现在检测到 `base_url` 含 `azure` 时自动切换；非 Azure 的 OpenAI o 系列推理模型可用 `AO_OPENAI_TOKENS_PARAM=max_completion_tokens` 显式覆盖（含回归测试 `test/azure-compat.ts`）。
 - **`ao prompt` 文档补齐**：Prompt Lab 合入后 `ao prompt` 一直没进 `ao --help` / README / CLAUDE.md，用户无从发现；现已补上（中英）。

--- a/website/package.json
+++ b/website/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "gen:experts": "node scripts/gen-experts.mjs",
+    "gen:workflows": "node scripts/gen-workflows.mjs",
     "build": "vite build",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview"

--- a/website/scripts/gen-workflows.mjs
+++ b/website/scripts/gen-workflows.mjs
@@ -1,0 +1,45 @@
+// 预生成「工作流模板」静态快照，供公开演示站(无后端)展示完整模板库。
+// 读取 repo 根的 workflows/*.yaml(中文)与 workflows/en/*.yaml(英文),
+// 产出 src/content/workflows.json（含 zh / en）。本地跑一次并提交。
+//   用法(在 repo 根)：node website/scripts/gen-workflows.mjs
+import { readdirSync, readFileSync, writeFileSync, existsSync, statSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..", "..");
+// js-yaml 在 repo 根 node_modules
+const require = createRequire(join(repoRoot, "package.json"));
+const yaml = require("js-yaml");
+
+function loadDir(dir) {
+  if (!existsSync(dir)) return [];
+  const out = [];
+  for (const f of readdirSync(dir)) {
+    if (!f.endsWith(".yaml") && !f.endsWith(".yml")) continue;
+    const full = join(dir, f);
+    try {
+      if (statSync(full).isDirectory()) continue;
+      const doc = yaml.load(readFileSync(full, "utf-8"));
+      if (!doc || !doc.name || !Array.isArray(doc.steps)) continue;
+      out.push({
+        name: String(doc.name),
+        description: doc.description ? String(doc.description) : "",
+        steps: doc.steps
+          .filter((s) => s && s.role)
+          .map((s) => ({ id: String(s.id || ""), role: String(s.role), name: s.name ? String(s.name) : undefined, emoji: s.emoji ? String(s.emoji) : undefined })),
+      });
+    } catch {
+      /* 跳过解析失败的模板 */
+    }
+  }
+  // 按步骤数(更有看头的排前)再按名字，稳定排序
+  return out.sort((a, b) => b.steps.length - a.steps.length || a.name.localeCompare(b.name));
+}
+
+const zh = loadDir(join(repoRoot, "workflows"));
+const en = loadDir(join(repoRoot, "workflows", "en"));
+const outFile = join(repoRoot, "website", "src", "content", "workflows.json");
+writeFileSync(outFile, JSON.stringify({ zh, en }, null, 2), "utf-8");
+console.log(`workflows.json: zh=${zh.length} en=${en.length} → ${outFile}`);

--- a/website/src/components/studio/WorkflowsPanel.tsx
+++ b/website/src/components/studio/WorkflowsPanel.tsx
@@ -99,9 +99,10 @@ export function WorkflowsPanel({ provider, onRun, demo, onInstallPrompt }: { pro
   useEffect(() => {
     setLoading(true);
     if (demo) {
-      // 演示模式：用静态模板快照，可浏览、看步骤，但运行时引导安装
+      // 演示模式：用内置模板的静态快照，可浏览、看步骤，但运行时引导安装
       import("@/lib/demo")
-        .then((m) => setWfs(m.demoWorkflows(lang)))
+        .then((m) => m.demoWorkflows(lang))
+        .then(setWfs)
         .catch(() => setWfs([]))
         .finally(() => setLoading(false));
       return;

--- a/website/src/content/workflows.json
+++ b/website/src/content/workflows.json
@@ -1,0 +1,822 @@
+{
+  "zh": [
+    {
+      "name": "AI 一人公司：全员大会",
+      "description": "你说一句话，9 个 AI 部门自动协作，2 分钟出完整商业方案——这就是一人公司",
+      "steps": [
+        {
+          "id": "ceo_kickoff",
+          "role": "strategy/nexus-strategy",
+          "name": "老板",
+          "emoji": "👔"
+        },
+        {
+          "id": "market_research",
+          "role": "product/product-trend-researcher",
+          "name": "市场调研员",
+          "emoji": "📊"
+        },
+        {
+          "id": "user_research",
+          "role": "design/design-ux-researcher",
+          "name": "用户研究员",
+          "emoji": "🔍"
+        },
+        {
+          "id": "tech_feasibility",
+          "role": "engineering/engineering-backend-architect",
+          "name": "技术总监",
+          "emoji": "💻"
+        },
+        {
+          "id": "brand_design",
+          "role": "design/design-brand-guardian",
+          "name": "品牌总监",
+          "emoji": "🎨"
+        },
+        {
+          "id": "product_plan",
+          "role": "product/product-manager",
+          "name": "产品经理",
+          "emoji": "🧭"
+        },
+        {
+          "id": "marketing_plan",
+          "role": "marketing/marketing-content-creator",
+          "name": "营销主管",
+          "emoji": "📣"
+        },
+        {
+          "id": "finance_plan",
+          "role": "finance/finance-financial-forecaster",
+          "name": "财务总监",
+          "emoji": "💰"
+        },
+        {
+          "id": "ceo_decision",
+          "role": "strategy/nexus-strategy",
+          "name": "老板",
+          "emoji": "👔"
+        }
+      ]
+    },
+    {
+      "name": "AI 一人公司：SaaS 产品发布决策",
+      "description": "CEO 一句话启动，5 个 AI 部门并行工作，30 秒出完整发布方案",
+      "steps": [
+        {
+          "id": "ceo_vision",
+          "role": "strategy/nexus-strategy"
+        },
+        {
+          "id": "product_plan",
+          "role": "product/product-manager"
+        },
+        {
+          "id": "tech_plan",
+          "role": "engineering/engineering-backend-architect"
+        },
+        {
+          "id": "marketing_plan",
+          "role": "marketing/marketing-content-creator"
+        },
+        {
+          "id": "finance_plan",
+          "role": "finance/finance-financial-forecaster"
+        },
+        {
+          "id": "launch_decision",
+          "role": "strategy/nexus-strategy"
+        }
+      ]
+    },
+    {
+      "name": "产品发布物料生成",
+      "description": "输入新产品/功能简介，并行产出发布通稿 + 社交短文 + 客户邮件 → 整合发布物料包",
+      "steps": [
+        {
+          "id": "positioning",
+          "role": "marketing/marketing-social-media-strategist",
+          "name": "市场策略",
+          "emoji": "🎯"
+        },
+        {
+          "id": "press_release",
+          "role": "marketing/marketing-content-creator",
+          "name": "通稿主笔",
+          "emoji": "📰"
+        },
+        {
+          "id": "social_short",
+          "role": "marketing/marketing-social-media-strategist",
+          "name": "社交短文",
+          "emoji": "📱"
+        },
+        {
+          "id": "customer_email",
+          "role": "marketing/marketing-content-creator",
+          "name": "邮件主笔",
+          "emoji": "✉️"
+        },
+        {
+          "id": "launch_pack",
+          "role": "marketing/marketing-content-creator",
+          "name": "发布物料整理员",
+          "emoji": "📦"
+        }
+      ]
+    },
+    {
+      "name": "创业 Pitch Deck 大纲",
+      "description": "输入一句话项目，并行输出市场分析 / 商业模式 / 财务预估 → 整合 5 屏 deck 大纲（创始人评审用）",
+      "steps": [
+        {
+          "id": "market_analysis",
+          "role": "product/product-trend-researcher",
+          "name": "市场研究员",
+          "emoji": "🔍"
+        },
+        {
+          "id": "solution_design",
+          "role": "product/product-manager",
+          "name": "产品方案",
+          "emoji": "💡"
+        },
+        {
+          "id": "business_model",
+          "role": "specialized/specialized-pricing-optimizer",
+          "name": "商业模式",
+          "emoji": "💰"
+        },
+        {
+          "id": "financial_projection",
+          "role": "finance/finance-financial-forecaster",
+          "name": "财务预估",
+          "emoji": "📈"
+        },
+        {
+          "id": "deck_outline",
+          "role": "product/product-manager",
+          "name": "Deck 主笔",
+          "emoji": "📊"
+        }
+      ]
+    },
+    {
+      "name": "会议纪要整理",
+      "description": "输入原始会议记录，自动整理为结构化纪要：决策、TODO、争议点 三视角并行 → 完整纪要",
+      "steps": [
+        {
+          "id": "organize",
+          "role": "specialized/specialized-meeting-assistant",
+          "name": "速记整理员",
+          "emoji": "📝"
+        },
+        {
+          "id": "extract_decisions",
+          "role": "specialized/specialized-meeting-assistant",
+          "name": "决策分析员",
+          "emoji": "✅"
+        },
+        {
+          "id": "extract_todos",
+          "role": "specialized/specialized-meeting-assistant",
+          "name": "行动跟踪员",
+          "emoji": "📌"
+        },
+        {
+          "id": "extract_concerns",
+          "role": "specialized/specialized-meeting-assistant",
+          "name": "争议追踪员",
+          "emoji": "⚠️"
+        },
+        {
+          "id": "final_notes",
+          "role": "specialized/specialized-meeting-assistant",
+          "name": "纪要主笔",
+          "emoji": "📄"
+        }
+      ]
+    },
+    {
+      "name": "AI 爆款深度文章",
+      "description": "多角色协作写一篇有深度、引人入胜的 AI 观点文章 — 调研、构思、写作、审校",
+      "steps": [
+        {
+          "id": "trend_research",
+          "role": "product/product-trend-researcher"
+        },
+        {
+          "id": "narrative_design",
+          "role": "academic/academic-narratologist"
+        },
+        {
+          "id": "depth_thinking",
+          "role": "academic/academic-narratologist"
+        },
+        {
+          "id": "write_article",
+          "role": "marketing/marketing-content-creator"
+        },
+        {
+          "id": "polish",
+          "role": "marketing/marketing-content-creator"
+        }
+      ]
+    },
+    {
+      "name": "产品需求评审",
+      "description": "多角色协作评审 PRD 文档 — 产品经理分析需求，架构师评估技术，设计师评估体验，最后汇总结论",
+      "steps": [
+        {
+          "id": "analyze",
+          "role": "product/product-manager"
+        },
+        {
+          "id": "tech_review",
+          "role": "engineering/engineering-software-architect"
+        },
+        {
+          "id": "design_review",
+          "role": "design/design-ux-researcher"
+        },
+        {
+          "id": "final_summary",
+          "role": "product/product-manager"
+        }
+      ]
+    },
+    {
+      "name": "抖音口播脚本创作",
+      "description": "一句话选题 → 爆款选题分析 + 逐秒脚本 + 标题钩子 + 拍摄建议",
+      "steps": [
+        {
+          "id": "angle",
+          "role": "marketing/marketing-douyin-strategist",
+          "name": "抖音选题官",
+          "emoji": "🎬"
+        },
+        {
+          "id": "script",
+          "role": "marketing/marketing-content-creator",
+          "name": "口播编剧",
+          "emoji": "✍️"
+        },
+        {
+          "id": "titles",
+          "role": "marketing/marketing-douyin-strategist",
+          "name": "标题钩子专家",
+          "emoji": "🎯"
+        },
+        {
+          "id": "final",
+          "role": "marketing/marketing-content-creator",
+          "name": "整合导演",
+          "emoji": "🎥"
+        }
+      ]
+    },
+    {
+      "name": "短篇小说创作",
+      "description": "从创意到成稿：叙事学家设计结构 → 心理学家塑造人物 + 叙事设计师构建冲突 → 内容创作者执笔成稿",
+      "steps": [
+        {
+          "id": "story_structure",
+          "role": "academic/academic-narratologist"
+        },
+        {
+          "id": "character_design",
+          "role": "academic/academic-psychologist"
+        },
+        {
+          "id": "conflict_design",
+          "role": "game-development/narrative-designer"
+        },
+        {
+          "id": "write_story",
+          "role": "marketing/marketing-content-creator"
+        }
+      ]
+    },
+    {
+      "name": "法律咨询意见书",
+      "description": "事实梳理 + 合同/文书审查 + 风险识别 + 法律意见书",
+      "steps": [
+        {
+          "id": "intake",
+          "role": "specialized/legal-client-intake",
+          "name": "法务助理",
+          "emoji": "📋"
+        },
+        {
+          "id": "document_review",
+          "role": "legal/legal-contract-reviewer",
+          "name": "合同/文书审查",
+          "emoji": "📄"
+        },
+        {
+          "id": "legal_risk",
+          "role": "specialized/legal-document-review",
+          "name": "诉讼风险顾问",
+          "emoji": "⚖️"
+        },
+        {
+          "id": "opinion",
+          "role": "legal/legal-policy-writer",
+          "name": "主办律师",
+          "emoji": "💼"
+        }
+      ]
+    },
+    {
+      "name": "技术博客创作",
+      "description": "输入一句话主题，自动完成趋势调研 → 大纲 → 正文 → 润色，输出可直接发布的技术博客",
+      "steps": [
+        {
+          "id": "research",
+          "role": "product/product-trend-researcher",
+          "name": "研究员",
+          "emoji": "🔬"
+        },
+        {
+          "id": "outline",
+          "role": "engineering/engineering-technical-writer",
+          "name": "技术作家",
+          "emoji": "✍️"
+        },
+        {
+          "id": "draft",
+          "role": "engineering/engineering-senior-developer",
+          "name": "资深开发",
+          "emoji": "💻"
+        },
+        {
+          "id": "polish",
+          "role": "engineering/engineering-technical-writer",
+          "name": "校对编辑",
+          "emoji": "🧹"
+        }
+      ]
+    },
+    {
+      "name": "简历优化与面试准备",
+      "description": "简历诊断 → 简历重写 + 面试问题预测 + STAR 答题框架",
+      "steps": [
+        {
+          "id": "diagnose",
+          "role": "hr/hr-recruiter",
+          "name": "资深 HR",
+          "emoji": "👔"
+        },
+        {
+          "id": "rewrite",
+          "role": "hr/hr-recruiter",
+          "name": "简历优化师",
+          "emoji": "✍️"
+        },
+        {
+          "id": "predict_questions",
+          "role": "hr/hr-recruiter",
+          "name": "面试官",
+          "emoji": "❓"
+        },
+        {
+          "id": "star_answers",
+          "role": "hr/hr-performance-reviewer",
+          "name": "答题教练",
+          "emoji": "🎯"
+        }
+      ]
+    },
+    {
+      "name": "内容创作流水线",
+      "description": "从主题到成稿的完整内容创作流程 — 研究、写作、品牌审核",
+      "steps": [
+        {
+          "id": "research",
+          "role": "marketing/marketing-social-media-strategist"
+        },
+        {
+          "id": "draft",
+          "role": "marketing/marketing-content-creator"
+        },
+        {
+          "id": "brand_review",
+          "role": "marketing/marketing-growth-hacker"
+        },
+        {
+          "id": "final_edit",
+          "role": "marketing/marketing-content-creator"
+        }
+      ]
+    },
+    {
+      "name": "投资标的分析（股票/基金/行业）",
+      "description": "基本面研究 + 财务分析 + 风险识别 + CFO 综合建议",
+      "steps": [
+        {
+          "id": "research",
+          "role": "finance/finance-investment-researcher",
+          "name": "投资研究员",
+          "emoji": "🔬"
+        },
+        {
+          "id": "financial",
+          "role": "finance/finance-financial-analyst",
+          "name": "财务分析师",
+          "emoji": "📊"
+        },
+        {
+          "id": "risk",
+          "role": "finance/finance-fraud-detector",
+          "name": "风控专家",
+          "emoji": "⚠️"
+        },
+        {
+          "id": "cfo_opinion",
+          "role": "finance/finance-financial-forecaster",
+          "name": "CFO 顾问",
+          "emoji": "💼"
+        }
+      ]
+    },
+    {
+      "name": "小红书爆款笔记创作",
+      "description": "一句话主题 → 策略分析 + 文案撰写 + SEO 标题 + 整合成稿",
+      "steps": [
+        {
+          "id": "strategy",
+          "role": "marketing/marketing-xiaohongshu-specialist",
+          "name": "小红书策略师",
+          "emoji": "📱"
+        },
+        {
+          "id": "copy",
+          "role": "marketing/marketing-content-creator",
+          "name": "文案创作",
+          "emoji": "✍️"
+        },
+        {
+          "id": "title",
+          "role": "marketing/marketing-baidu-seo-specialist",
+          "name": "标题+标签专家",
+          "emoji": "🎯"
+        },
+        {
+          "id": "final",
+          "role": "marketing/marketing-content-creator",
+          "name": "整合发稿",
+          "emoji": "📝"
+        }
+      ]
+    },
+    {
+      "name": "学术论文选题与大纲",
+      "description": "选题评估 + 研究方法设计 + 文献综述框架 + 完整大纲",
+      "steps": [
+        {
+          "id": "topic_eval",
+          "role": "academic/academic-study-planner",
+          "name": "选题导师",
+          "emoji": "🎓"
+        },
+        {
+          "id": "methodology",
+          "role": "academic/academic-study-planner",
+          "name": "方法论设计师",
+          "emoji": "🔬"
+        },
+        {
+          "id": "literature",
+          "role": "academic/academic-historian",
+          "name": "文献综述专家",
+          "emoji": "📚"
+        },
+        {
+          "id": "outline",
+          "role": "academic/academic-study-planner",
+          "name": "论文架构师",
+          "emoji": "📝"
+        }
+      ]
+    },
+    {
+      "name": "Codex + Claude Code 协作编程(闭环版)",
+      "description": "",
+      "steps": [
+        {
+          "id": "plan",
+          "role": "engineering/engineering-backend-architect"
+        },
+        {
+          "id": "implement",
+          "role": "engineering/engineering-rapid-prototyper"
+        },
+        {
+          "id": "review",
+          "role": "testing/testing-reality-checker"
+        },
+        {
+          "id": "fix",
+          "role": "engineering/engineering-rapid-prototyper"
+        }
+      ]
+    },
+    {
+      "name": "OKR 拆解",
+      "description": "输入年度目标，自动完成现状分析 → 4 个季度 KR 拆解 → 首季度行动方案 → 完整 OKR 文档",
+      "steps": [
+        {
+          "id": "situation_analysis",
+          "role": "product/product-manager",
+          "name": "现状分析师",
+          "emoji": "📊"
+        },
+        {
+          "id": "quarterly_plan",
+          "role": "project-management/project-manager-senior",
+          "name": "项目总监",
+          "emoji": "📅"
+        },
+        {
+          "id": "q1_action_plan",
+          "role": "marketing/marketing-growth-hacker",
+          "name": "Q1 操盘手",
+          "emoji": "🚀"
+        },
+        {
+          "id": "final_okr",
+          "role": "project-management/project-manager-senior",
+          "name": "OKR 主笔",
+          "emoji": "📄"
+        }
+      ]
+    },
+    {
+      "name": "Codex + Claude Code 协作编程(极简版)",
+      "description": "",
+      "steps": [
+        {
+          "id": "plan",
+          "role": "engineering/engineering-backend-architect"
+        },
+        {
+          "id": "implement",
+          "role": "engineering/engineering-rapid-prototyper"
+        },
+        {
+          "id": "review",
+          "role": "testing/testing-reality-checker"
+        }
+      ]
+    }
+  ],
+  "en": [
+    {
+      "name": "Solo Founder All-Hands",
+      "description": "One sentence in, 8 AI 'departments' collaborate, full launch plan out in 2 minutes — your one-person company",
+      "steps": [
+        {
+          "id": "ceo_kickoff",
+          "role": "strategy/nexus-strategy",
+          "name": "CEO",
+          "emoji": "👔"
+        },
+        {
+          "id": "market_research",
+          "role": "product/product-trend-researcher",
+          "name": "Market Researcher",
+          "emoji": "📊"
+        },
+        {
+          "id": "user_research",
+          "role": "design/design-ux-researcher",
+          "name": "User Researcher",
+          "emoji": "🔍"
+        },
+        {
+          "id": "tech_feasibility",
+          "role": "engineering/engineering-backend-architect",
+          "name": "Tech Lead",
+          "emoji": "💻"
+        },
+        {
+          "id": "brand_design",
+          "role": "design/design-brand-guardian",
+          "name": "Brand Director",
+          "emoji": "🎨"
+        },
+        {
+          "id": "product_plan",
+          "role": "product/product-manager",
+          "name": "Product Manager",
+          "emoji": "🧭"
+        },
+        {
+          "id": "marketing_plan",
+          "role": "marketing/marketing-content-creator",
+          "name": "Marketing Lead",
+          "emoji": "📣"
+        },
+        {
+          "id": "finance_plan",
+          "role": "finance/finance-fpa-analyst",
+          "name": "CFO",
+          "emoji": "💰"
+        },
+        {
+          "id": "ceo_decision",
+          "role": "strategy/nexus-strategy",
+          "name": "CEO",
+          "emoji": "👔"
+        }
+      ]
+    },
+    {
+      "name": "Business Plan",
+      "description": "Market research → financial forecast + product roadmap → executive summary — generates a complete business plan",
+      "steps": [
+        {
+          "id": "market_research",
+          "role": "product/product-trend-researcher"
+        },
+        {
+          "id": "financial_model",
+          "role": "finance/finance-fpa-analyst"
+        },
+        {
+          "id": "product_roadmap",
+          "role": "product/product-manager"
+        },
+        {
+          "id": "executive_summary",
+          "role": "support/support-executive-summary-generator"
+        }
+      ]
+    },
+    {
+      "name": "Competitor Analysis Report",
+      "description": "Trend research → data analysis + SEO scan → executive summary — a report ready to present",
+      "steps": [
+        {
+          "id": "trend_research",
+          "role": "product/product-trend-researcher"
+        },
+        {
+          "id": "data_analysis",
+          "role": "support/support-analytics-reporter"
+        },
+        {
+          "id": "seo_scan",
+          "role": "marketing/marketing-seo-specialist"
+        },
+        {
+          "id": "executive_summary",
+          "role": "support/support-executive-summary-generator"
+        }
+      ]
+    },
+    {
+      "name": "Content Creation Pipeline",
+      "description": "Topic to finished draft — research, write, brand review, final edit",
+      "steps": [
+        {
+          "id": "research",
+          "role": "marketing/marketing-social-media-strategist"
+        },
+        {
+          "id": "draft",
+          "role": "marketing/marketing-content-creator"
+        },
+        {
+          "id": "brand_review",
+          "role": "marketing/marketing-growth-hacker"
+        },
+        {
+          "id": "final_edit",
+          "role": "marketing/marketing-content-creator"
+        }
+      ]
+    },
+    {
+      "name": "PR Code Review",
+      "description": "Three-dimensional parallel review: code quality, security, performance → unified verdict",
+      "steps": [
+        {
+          "id": "code_quality",
+          "role": "engineering/engineering-code-reviewer"
+        },
+        {
+          "id": "security_check",
+          "role": "engineering/engineering-security-engineer"
+        },
+        {
+          "id": "perf_check",
+          "role": "testing/testing-performance-benchmarker"
+        },
+        {
+          "id": "summary",
+          "role": "engineering/engineering-code-reviewer"
+        }
+      ]
+    },
+    {
+      "name": "Product Requirements Review",
+      "description": "Multi-role PRD review — PM analyzes requirements, architect assesses tech, UX researcher assesses experience, then synthesis",
+      "steps": [
+        {
+          "id": "analyze",
+          "role": "product/product-manager"
+        },
+        {
+          "id": "tech_review",
+          "role": "engineering/engineering-software-architect"
+        },
+        {
+          "id": "design_review",
+          "role": "design/design-ux-researcher"
+        },
+        {
+          "id": "final_summary",
+          "role": "product/product-manager"
+        }
+      ]
+    },
+    {
+      "name": "Tech Blog",
+      "description": "Research → outline → draft → polish: a deep, credible technical blog post.",
+      "steps": [
+        {
+          "id": "research",
+          "role": "product/product-trend-researcher"
+        },
+        {
+          "id": "outline",
+          "role": "engineering/engineering-technical-writer"
+        },
+        {
+          "id": "draft",
+          "role": "engineering/engineering-senior-developer"
+        },
+        {
+          "id": "polish",
+          "role": "engineering/engineering-technical-writer"
+        }
+      ]
+    },
+    {
+      "name": "Code Architecture Review",
+      "description": "Architecture design → backend deep-dive → code review for a feature or system.",
+      "steps": [
+        {
+          "id": "architecture",
+          "role": "engineering/engineering-software-architect"
+        },
+        {
+          "id": "backend",
+          "role": "engineering/engineering-backend-architect"
+        },
+        {
+          "id": "review",
+          "role": "engineering/engineering-code-reviewer"
+        }
+      ]
+    },
+    {
+      "name": "Investment Analysis",
+      "description": "Research → fundamentals → financial modeling: a structured analysis of a target.",
+      "steps": [
+        {
+          "id": "research",
+          "role": "finance/finance-investment-researcher"
+        },
+        {
+          "id": "fundamentals",
+          "role": "finance/finance-financial-analyst"
+        },
+        {
+          "id": "plan",
+          "role": "finance/finance-fpa-analyst"
+        }
+      ]
+    },
+    {
+      "name": "OKR Decomposition",
+      "description": "Annual goal → quarterly KRs → a concrete Q1 action plan.",
+      "steps": [
+        {
+          "id": "analyze",
+          "role": "product/product-manager"
+        },
+        {
+          "id": "kr_design",
+          "role": "project-management/project-manager-senior"
+        },
+        {
+          "id": "q1_plan",
+          "role": "project-management/project-management-project-shepherd"
+        }
+      ]
+    }
+  ]
+}

--- a/website/src/lib/demo.ts
+++ b/website/src/lib/demo.ts
@@ -38,70 +38,21 @@ export async function demoRoleContent(lang: "zh" | "en", category: string, id: s
   return res.text();
 }
 
-// 演示模式工作流：公开站无后端，这里给一组内置模板的静态快照，可浏览 / 看步骤，但不能真跑。
-type DemoWf = { name: { zh: string; en: string }; desc: { zh: string; en: string }; steps: { role: string; name: { zh: string; en: string }; emoji: string }[] };
-const DEMO_WORKFLOWS: DemoWf[] = [
-  {
-    name: { zh: "技术博客创作", en: "Tech Blog" },
-    desc: { zh: "一句话主题 → 趋势调研 → 大纲 → 正文 → 润色，输出可发布的技术博客", en: "One topic → research → outline → draft → polish into a publishable post" },
-    steps: [
-      { role: "product/product-trend-researcher", name: { zh: "趋势研究员", en: "Trend Researcher" }, emoji: "🔬" },
-      { role: "engineering/engineering-technical-writer", name: { zh: "技术作家", en: "Tech Writer" }, emoji: "✍️" },
-      { role: "engineering/engineering-senior-developer", name: { zh: "资深开发", en: "Senior Dev" }, emoji: "💻" },
-    ],
-  },
-  {
-    name: { zh: "创业可行性分析", en: "Startup Feasibility" },
-    desc: { zh: "市场 / 用户 / 产品 / 财务多角度并行评估，输出可行性结论", en: "Parallel market / user / product / finance analysis → feasibility verdict" },
-    steps: [
-      { role: "product/product-market-researcher", name: { zh: "市场研究员", en: "Market Researcher" }, emoji: "📊" },
-      { role: "product/product-user-researcher", name: { zh: "用户研究员", en: "User Researcher" }, emoji: "🔍" },
-      { role: "finance/finance-cfo", name: { zh: "财务总监", en: "CFO" }, emoji: "💰" },
-    ],
-  },
-  {
-    name: { zh: "PR 代码审查", en: "PR Code Review" },
-    desc: { zh: "安全 / 性能 / 可读性三路并行审查 → 汇总修改建议", en: "Security / performance / readability review in parallel → consolidated feedback" },
-    steps: [
-      { role: "engineering/engineering-code-reviewer", name: { zh: "代码审查员", en: "Code Reviewer" }, emoji: "🔍" },
-      { role: "engineering/engineering-security-engineer", name: { zh: "安全工程师", en: "Security Eng" }, emoji: "🛡️" },
-    ],
-  },
-  {
-    name: { zh: "小红书爆款文案", en: "Viral Social Post" },
-    desc: { zh: "选题 → 标题 → 正文 → 标签，产出一篇可直接发的小红书笔记", en: "Topic → hook → body → tags: a ready-to-post note" },
-    steps: [
-      { role: "marketing/marketing-growth-hacker", name: { zh: "增长黑客", en: "Growth Hacker" }, emoji: "🚀" },
-      { role: "marketing/marketing-content-creator", name: { zh: "内容创作者", en: "Content Creator" }, emoji: "✍️" },
-    ],
-  },
-  {
-    name: { zh: "会议纪要整理", en: "Meeting Notes" },
-    desc: { zh: "清理 → 决策 / TODO / 争议三视角并行 → 整合成结构化纪要", en: "Clean up → decisions / TODOs / disputes → structured minutes" },
-    steps: [
-      { role: "operations/operations-chief-of-staff", name: { zh: "幕僚长", en: "Chief of Staff" }, emoji: "📋" },
-      { role: "product/product-manager", name: { zh: "产品经理", en: "Product Manager" }, emoji: "🧭" },
-    ],
-  },
-  {
-    name: { zh: "OKR 拆解", en: "OKR Breakdown" },
-    desc: { zh: "现状分析 → 季度 KR → 行动方案 → 完整 OKR 文档", en: "Status → quarterly KRs → action plan → full OKR doc" },
-    steps: [
-      { role: "operations/operations-chief-of-staff", name: { zh: "战略幕僚", en: "Strategist" }, emoji: "🎯" },
-      { role: "product/product-manager", name: { zh: "产品经理", en: "Product Manager" }, emoji: "🧭" },
-    ],
-  },
-];
+// 演示模式工作流：公开站无后端，读取内置模板的静态快照(由 scripts/gen-workflows.mjs 生成)，
+// 可浏览 / 看步骤，但不能真跑。
+interface WfSnapshot { name: string; description: string; steps: { id?: string; role: string; name?: string; emoji?: string }[] }
 
-/** 演示模式工作流列表(静态快照，标 private=false，file 用 demo:// 占位，不可真跑)。 */
-export function demoWorkflows(lang: "zh" | "en"): Workflow[] {
-  return DEMO_WORKFLOWS.map((w, i) => ({
+/** 演示模式工作流列表(完整内置模板快照，file 用 demo:// 占位，不可真跑)。 */
+export async function demoWorkflows(lang: "zh" | "en"): Promise<Workflow[]> {
+  const data = (await import("@/content/workflows.json")).default as { zh: WfSnapshot[]; en: WfSnapshot[] };
+  const arr = (lang === "en" ? data.en : data.zh) ?? data.zh ?? [];
+  return arr.map((w, i) => ({
     file: `demo://${i}`,
-    filename: `${w.name.en.toLowerCase().replace(/\s+/g, "-")}.yaml`,
-    name: w.name[lang],
-    description: w.desc[lang],
+    filename: `${i}.yaml`,
+    name: w.name,
+    description: w.description,
     inputs: [],
-    steps: w.steps.map((s, j) => ({ id: `step_${j + 1}`, role: s.role, name: s.name[lang], emoji: s.emoji })),
+    steps: w.steps.map((s, j) => ({ id: s.id || `step_${j + 1}`, role: s.role, name: s.name, emoji: s.emoji })),
     private: false,
   }));
 }

--- a/website/src/pages/Studio.tsx
+++ b/website/src/pages/Studio.tsx
@@ -170,11 +170,17 @@ function StudioInner() {
                 <WorkflowsPanel provider={provider} onRun={start} demo onInstallPrompt={() => setInstallOpen(true)} />
               ) : tab === "prompt" ? (
                 <PromptLab provider={provider} demo onInstallPrompt={() => setInstallOpen(true)} />
-              ) : tab === "runs" || tab === "usage" ? (
-                <p className="py-16 text-center text-sm text-muted-foreground">
+              ) : tab === "runs" ? (
+                <p className="mx-auto max-w-md py-16 text-center text-sm text-muted-foreground">
                   {lang === "en"
-                    ? "Nothing here in demo mode yet — run a workflow locally and it'll show up."
-                    : "演示模式下这里还没有数据，本地实际跑过工作流后就会出现。"}
+                    ? "Run History — demo mode has no records yet. Once you run workflows locally, each run's outputs, duration and tokens show here, and you can re-run from any step."
+                    : "运行历史 —— 演示模式还没有记录。本地实际跑过工作流后，这里会列出每次运行的产物、耗时与 token，并支持从任意步骤重跑。"}
+                </p>
+              ) : tab === "usage" ? (
+                <p className="mx-auto max-w-md py-16 text-center text-sm text-muted-foreground">
+                  {lang === "en"
+                    ? "Usage — demo mode has no data yet. After real local runs, this tab charts token usage and estimated cost by day and by role."
+                    : "用量统计 —— 演示模式还没有数据。本地实际调用后，这里按天 / 按角色统计 token 用量与估算成本。"}
                 </p>
               ) : (
                 <>


### PR DESCRIPTION
修两处演示页反馈:
1. **工作流太少**:演示模式之前只放了 6 个手写模板。改为读取**全部内置模板的静态快照**——新增 `gen-workflows.mjs` 把 `workflows/*.yaml`(19 中文)+ `workflows/en`(10 英文)生成 `workflows.json`,`demoWorkflows` 读它。演示页现在展示完整模板库。
2. **运行历史 / 用量「点击都不动、显示同一个」**:这两个 tab 之前共用同一句占位文案,切过去看着没变化。现在各给独立说明(运行历史讲产物/耗时/重跑,用量讲 token/成本统计)。

构建通过,完整快照与区分文案均已进 bundle。