### PR TITLE
feat(skills): 步骤可挂方法论 skill (MVP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **`ao prompt` 文档补齐**：Prompt Lab 合入后 `ao prompt` 一直没进 `ao --help` / README / CLAUDE.md，用户无从发现；现已补上（中英）。
 
 ### Added
+- **Skills(给步骤挂方法论)**：工作流步骤可加 `skill: "<名字>"`(或 `skills: [..]`)，把「怎么做」的方法论(流程剧本)注入该步的 system prompt——角色决定谁做、skill 决定怎么做。内容直接用开源 **superpowers-zh**(MIT,20 个,已作为依赖,零配置);`AO_SKILLS_DIR` 可换成自己的。`ao skills [名字]` 列出 / 查看;缺失的 skill 跳过不报错。
 - **固定全局目录 `AO_HOME`**（#20）：设 `AO_HOME=~/.ao`（或任意目录）后，运行产物 `ao-output` 与 `compose`/`--team` 生成的工作流统一落到该目录，不再随执行目录散落；也可用 `AO_OUTPUT_DIR` / `AO_WORKFLOWS_DIR` 单独指定。**默认不设时维持原行为**（写到当前目录），向后兼容。团队 / 提示词 / 版本检查一直在 `~/.ao`。
 - **团队 / Loadout（可复用角色阵容）**：把跑得好的角色阵容存下来，套到任意新任务上。
   - CLI：`ao team save <workflow.yaml>` 从工作流抽出阵容存为团队；`ao team list / show / rm` 管理；`ao run --team <名字> "新任务"` 用固定阵容跑新活（本质 = compose 时把可选角色锁定为团队那几个，不漏人也不幻觉）。团队存为 `~/.ao/teams/*.team.yaml`（纯 YAML 可分享，`AO_TEAMS_DIR` 可覆盖）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,15 @@ ao team list / show / rm              # Manage saved teams (stored in ~/.ao/team
 ao run --team <name> "task"           # Run a new task with a saved team (locked line-up)
 ao prompt optimize "<prompt>"         # AI-optimize a prompt (--mode system|user, --save)
 ao prompt test / list / show / rm / garden  # Prompt Lab: test / manage / starter templates
+ao skills [name]                      # List / view methodology skills (superpowers-zh) for step `skill:`
 ```
+
+## Skills (methodology playbooks)
+
+A step can carry `skill: "<name>"` (or `skills: [..]`) — the methodology body is injected into that
+step's system prompt at run time (`src/skills/loader.ts`, applied in `core/executor.ts`). Content
+comes from the `superpowers-zh` dependency (`node_modules/superpowers-zh/skills/<name>/SKILL.md`);
+override the source dir with `AO_SKILLS_DIR`. Missing skills are skipped (warn), never fatal.
 
 ## Prompt Lab
 
@@ -95,6 +103,7 @@ steps:
     role: "category/role-name"       # from agency-agents-zh
     task: "Task with {{variables}}"
     output: output_variable
+    skill: "test-driven-development" # optional: inject a methodology playbook (see `ao skills`)
     depends_on: [other_step]         # DAG dependency
     condition: "{{var}} contains X"  # conditional branching
     loop:                            # iterative loop

--- a/README.en.md
+++ b/README.en.md
@@ -264,6 +264,7 @@ ao team list / show / rm             # Manage saved teams
 ao run --team <name> "new task"      # Run a new task with a saved team (locked line-up)
 ao prompt optimize "<prompt>"        # AI-optimize a prompt (--save to keep it reusable)
 ao prompt test / list / garden       # Test / manage / starter templates (prompt library)
+ao skills [name]                     # List / view methodology skills to attach to steps
 ao run <workflow.yaml> [options]      # Execute workflow
 ao validate <workflow.yaml>          # Validate without running
 ao plan <workflow.yaml>              # Show execution plan (DAG)
@@ -331,6 +332,25 @@ ao prompt garden                    # built-in starter templates
 ```
 
 `--mode system|user` distinguishes role/system prompts from task prompts. Optimize only ever produces a **better prompt** (it never executes the prompt). The Studio "Prompts" tab adds side-by-side original-vs-optimized comparison **with AI scoring**. Stored in `~/.ao/prompts/` (`AO_PROMPTS_DIR` to override), shared between CLI and Studio.
+
+### Skills (attach a methodology to a step)
+
+Roles decide *who* does it; skills decide *how*. Attach a **skill** (a methodology playbook) to a workflow step and its method is injected into that step — e.g. make the review step follow a structured review method, or the implementation step do TDD:
+
+```yaml
+steps:
+  - id: review
+    role: "engineering/engineering-code-reviewer"
+    skill: "chinese-code-review"     # single; or skills: ["test-driven-development", ...]
+    task: "Review this code {{code}}"
+```
+
+```bash
+ao skills                            # list all available skills
+ao skills test-driven-development    # view a skill's methodology
+```
+
+Skill content comes straight from the open-source [superpowers-zh](https://github.com/jnMetaCode/superpowers-zh) (MIT, 20 skills, bundled as a dependency — zero config). Or set `AO_SKILLS_DIR=/your/skills/dir` for your own.
 
 ### Resume & Iterate
 

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ ao team list / show / rm              # 管理已保存的团队
 ao run --team <名字> "新任务"          # 用已保存的团队跑新任务（锁定阵容）
 ao prompt optimize "提示词"           # AI 优化提示词（--save 存为可复用资产）
 ao prompt test / list / garden        # 测试 / 管理 / 起手模板（提示词沉淀）
+ao skills [名字]                       # 列出/查看可挂到步骤的方法论 skill
 ao run <workflow.yaml> [选项]          # 执行工作流
 ao validate <workflow.yaml>           # 校验（不执行）
 ao plan <workflow.yaml>               # 查看执行计划（DAG）
@@ -341,6 +342,25 @@ ao prompt garden                  # 内置起手模板
 ```
 
 `--mode system|user` 区分「角色/系统提示词」和「任务提示词」。优化只产出**更好的提示词**（不会直接去执行它）。网页 Studio 的「提示词」页还能原版 vs 优化版**并排对比 + AI 评分**。存在 `~/.ao/prompts/`（`AO_PROMPTS_DIR` 可改），命令行与 Studio 共用。
+
+### Skills（给步骤挂方法论）
+
+角色决定「谁来做」，skill 决定「怎么做」。给工作流某一步挂一个 **skill**（流程剧本），它的方法论会注入该步——比如让代码审查步骤遵循结构化审查法、让实现步骤走 TDD：
+
+```yaml
+steps:
+  - id: review
+    role: "engineering/engineering-code-reviewer"
+    skill: "chinese-code-review"     # 单个；或 skills: ["test-driven-development", ...]
+    task: "审查这段代码 {{code}}"
+```
+
+```bash
+ao skills                      # 列出全部可用 skill
+ao skills test-driven-development   # 看某个 skill 的方法论
+```
+
+skill 内容直接用开源的 [superpowers-zh](https://github.com/jnMetaCode/superpowers-zh)（MIT，20 个,已作为依赖,零配置）；也可设 `AO_SKILLS_DIR=/你的skill目录` 挂自己的。
 
 ### 迭代优化（Resume）
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "agency-orchestrator",
-  "version": "0.7.1",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agency-orchestrator",
-      "version": "0.7.1",
+      "version": "0.7.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",
         "@modelcontextprotocol/sdk": "^1.28.0",
         "agency-agents-zh": "^1.2.2",
-        "js-yaml": "^4.1.0"
+        "js-yaml": "^4.1.0",
+        "superpowers-zh": "^1.5.0"
       },
       "bin": {
         "agency-orchestrator": "dist/cli.js",
@@ -1121,6 +1122,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/superpowers-zh": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/superpowers-zh/-/superpowers-zh-1.5.0.tgz",
+      "integrity": "sha512-4SBz8YjxxQ+P+uFShnuffnBs+gkN9EYk6znPt4g50Mr0xD0nbCggGT1ciB2ygGUxBuv8PdrJYX3iwsYAqvYc/g==",
+      "license": "MIT",
+      "bin": {
+        "superpowers-zh": "bin/superpowers-zh.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/toidentifier": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "eval:gate": "npx tsx eval/run-eval.ts --gate",
     "eval:baseline": "npx tsx eval/run-eval.ts --save-baseline",
     "build:studio": "npm --prefix website install && npm --prefix website run build",
-    "test": "npx tsx test/run.ts && npx tsx test/condition.ts && npx tsx test/cli.ts && npx tsx test/cli-base.ts && npx tsx test/compose.ts && npx tsx test/demo.ts && npx tsx test/factory-custom.ts && npx tsx test/azure-compat.ts && npx tsx test/paths.ts && npx tsx test/step-llm.ts && npx tsx test/step-llm-yaml.ts && npx tsx test/stdin-limit.ts && npx tsx test/compose-name.ts && npx tsx test/team.ts && npx tsx test/prompt.ts && npx tsx test/upgrade.ts && npx tsx test/resume.ts && npx tsx test/feedback.ts && npx tsx test/human-input.ts && npx tsx test/init.ts && npx tsx test/roles.ts && npx tsx test/eval-gate.ts && npx tsx test/validate-report.ts && npx tsx test/workflows.ts && npx tsx test/timeout.ts && npx tsx test/inputs.ts && npx tsx test/e2e.ts && npx tsx test/e2e-condition.ts && npx tsx test/e2e-loop.ts && npx tsx test/mcp.ts",
+    "test": "npx tsx test/run.ts && npx tsx test/condition.ts && npx tsx test/cli.ts && npx tsx test/cli-base.ts && npx tsx test/compose.ts && npx tsx test/demo.ts && npx tsx test/factory-custom.ts && npx tsx test/azure-compat.ts && npx tsx test/paths.ts && npx tsx test/skills.ts && npx tsx test/step-llm.ts && npx tsx test/step-llm-yaml.ts && npx tsx test/stdin-limit.ts && npx tsx test/compose-name.ts && npx tsx test/team.ts && npx tsx test/prompt.ts && npx tsx test/upgrade.ts && npx tsx test/resume.ts && npx tsx test/feedback.ts && npx tsx test/human-input.ts && npx tsx test/init.ts && npx tsx test/roles.ts && npx tsx test/eval-gate.ts && npx tsx test/validate-report.ts && npx tsx test/workflows.ts && npx tsx test/timeout.ts && npx tsx test/inputs.ts && npx tsx test/e2e.ts && npx tsx test/e2e-condition.ts && npx tsx test/e2e-loop.ts && npx tsx test/mcp.ts",
     "prepublishOnly": "npm run build && npm run build:studio"
   },
   "files": [
@@ -89,7 +89,8 @@
     "@anthropic-ai/sdk": "^0.52.0",
     "@modelcontextprotocol/sdk": "^1.28.0",
     "agency-agents-zh": "^1.2.2",
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.0",
+    "superpowers-zh": "^1.5.0"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -75,6 +75,9 @@ async function main(): Promise<void> {
     case 'prompt':
       await handlePrompt();
       break;
+    case 'skills':
+      await handleSkills();
+      break;
     case 'demo':
       await handleDemo();
       break;
@@ -94,7 +97,7 @@ async function main(): Promise<void> {
       break;
     default: {
       // 容错：用户可能漏了空格，如 "planworkflows/x.yaml"
-      const knownCmds = ['run', 'validate', 'plan', 'explain', 'compose', 'team', 'prompt', 'demo', 'roles', 'init', 'serve', 'web', 'upgrade'];
+      const knownCmds = ['run', 'validate', 'plan', 'explain', 'compose', 'team', 'prompt', 'skills', 'demo', 'roles', 'init', 'serve', 'web', 'upgrade'];
       const match = knownCmds.find(c => command.startsWith(c) && command.length > c.length);
       if (match) {
         console.error(`看起来少了个空格？试试:\n  ao ${match} ${command.slice(match.length)}\n`);
@@ -816,6 +819,38 @@ async function handlePrompt(): Promise<void> {
     console.error(`\n${t('error.prefix')}: ${err instanceof Error ? err.message : err}`);
     process.exit(1);
   }
+}
+
+/** ao skills — 列出 / 查看可挂到工作流步骤的方法论 skill（来自 superpowers-zh）。 */
+async function handleSkills(): Promise<void> {
+  const S = await import('./skills/loader.js');
+  const dir = S.resolveSkillsDir();
+  const ref = args[1] && !args[1].startsWith('-') ? args[1] : '';
+
+  if (ref) {
+    const sk = S.loadSkill(ref);
+    if (!sk) { console.error(`找不到 skill "${ref}"。用 \`ao skills\` 查看全部。`); process.exit(1); }
+    console.log(`\n  🧠 ${sk.name}\n  ${sk.description}\n`);
+    console.log('─'.repeat(50));
+    console.log(sk.body);
+    console.log('─'.repeat(50));
+    console.log(`\n  在工作流步骤里挂上它：  skill: "${sk.name}"\n`);
+    return;
+  }
+
+  const all = S.listSkills();
+  if (!dir || all.length === 0) {
+    console.log(`\n  没找到 skill 库。skill 用开源的 superpowers-zh（已作为依赖）。`);
+    console.log(`  也可设 AO_SKILLS_DIR=/你的skill目录 用自己的。\n`);
+    return;
+  }
+  console.log(`\n  共 ${all.length} 个 skill (${dir}):\n`);
+  for (const sk of all) {
+    console.log(`  🧠 ${sk.name}`);
+    if (sk.description) console.log(`     ${sk.description.slice(0, 90)}`);
+  }
+  console.log(`\n  用法：在工作流步骤里加 skill: "<名字>"（或 skills: [..]），方法论会注入该步。`);
+  console.log(`  查看某个：ao skills <名字>\n`);
 }
 
 async function handleServe(): Promise<void> {

--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -13,6 +13,7 @@ import type { DAG } from './dag.js';
 import { renderTemplate } from './template.js';
 import { evaluateCondition } from './condition.js';
 import { loadAgent } from '../agents/loader.js';
+import { collectSkillNames, injectSkills } from '../skills/loader.js';
 import { createConnector } from '../connectors/factory.js';
 import { createInterface } from 'node:readline';
 
@@ -363,7 +364,16 @@ async function executeStep(
   const agent = loadAgent(opts.agentsDir, node.step.role);
   node.agentName = node.step.name || agent.name;
   node.agentEmoji = node.step.emoji || agent.emoji;
-  const systemPrompt = agent.systemPrompt;
+  let systemPrompt = agent.systemPrompt;
+
+  // 给本步挂 skill（流程剧本）→ 把方法论注入 system prompt 末尾。可选增强，缺失则跳过、不报错。
+  const skillNames = collectSkillNames(node.step);
+  if (skillNames.length) {
+    const inj = injectSkills(systemPrompt, skillNames);
+    systemPrompt = inj.prompt;
+    if (inj.applied.length) process.stderr.write(`  🧠 ${node.step.id} 挂载 skill: ${inj.applied.join(', ')}\n`);
+    if (inj.missing.length) process.stderr.write(`  ⚠️ 找不到 skill（已跳过）: ${inj.missing.join(', ')}\n`);
+  }
 
   // 渲染任务模板
   let userMessage = renderTemplate(node.step.task, opts.context);

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -203,6 +203,8 @@ const dict: Dict = {
     run --team <名字> "任务"           用已保存的团队跑新任务（锁定阵容）
     prompt optimize "提示词"          AI 优化提示词（--mode system|user，--save 存下来）
     prompt test / list / show / garden  测试 / 管理 / 起手模板（提示词沉淀）
+    skills                            列出可挂到步骤的方法论 skill（来自 superpowers-zh）
+    skills <名字>                     查看某个 skill 的方法论正文
     serve                             启动 MCP Server（供 Claude Code / Cursor 调用）
     web                               启动可视化 Web Studio（浏览器里勾角色组队、跑工作流）
     run <workflow.yaml>               执行工作流
@@ -268,6 +270,7 @@ const dict: Dict = {
     run --team <name> "task"          Run a new task with a saved team (locked line-up)
     prompt optimize "<prompt>"        AI-optimize a prompt (--mode system|user, --save to keep)
     prompt test / list / show / garden  Test / manage / starter templates (prompt library)
+    skills [name]                     List / view methodology skills (from superpowers-zh) to attach to steps
     serve                             Start MCP server (for Claude Code / Cursor)
     web                               Launch the visual Web Studio (pick roles & run in the browser)
     run <workflow.yaml>               Execute a workflow

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -1,0 +1,112 @@
+/**
+ * Skills（流程剧本）—— 给工作流步骤挂一套「怎么做」的方法论，注入该步的 system prompt。
+ *
+ * 内容直接用开源的 superpowers-zh（MIT，20 个 skill），不自己写。
+ * 每个 skill = <skillsDir>/<name>/SKILL.md（frontmatter: name/description + 正文方法论）。
+ *
+ * skillsDir 解析优先级：AO_SKILLS_DIR > ./skills > ./superpowers-zh/skills >
+ *   ../superpowers-zh/skills > node_modules/superpowers-zh/skills（cwd 与包自身）。
+ * 与 angency-agents 角色库同理：可被 AO_SKILLS_DIR 覆盖成你自己的 skill 目录。
+ */
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export interface SkillDefinition {
+  name: string;
+  description: string;
+  body: string;       // SKILL.md frontmatter 之后的方法论正文
+}
+
+let _cachedDir: string | null | undefined;
+
+/** 解析 skills 目录（缓存）。找不到返回 null（skills 是可选增强，不报错）。 */
+export function resolveSkillsDir(): string | null {
+  if (_cachedDir !== undefined) return _cachedDir;
+  const scriptDir = dirname(fileURLToPath(import.meta.url)); // dist/skills
+  const candidates = [
+    process.env.AO_SKILLS_DIR,
+    './skills',
+    './superpowers-zh/skills',
+    '../superpowers-zh/skills',
+    './node_modules/superpowers-zh/skills',
+    join(scriptDir, '..', '..', 'node_modules', 'superpowers-zh', 'skills'),   // 包自身 node_modules
+    join(scriptDir, '..', '..', '..', 'node_modules', 'superpowers-zh', 'skills'), // hoisted
+    join(scriptDir, '..', '..', '..', 'superpowers-zh', 'skills'),             // sibling clone
+  ].filter(Boolean) as string[];
+  for (const c of candidates) {
+    const full = resolve(c);
+    if (existsSync(full)) { _cachedDir = full; return full; }
+  }
+  _cachedDir = null;
+  return null;
+}
+
+/** 仅供测试：重置目录缓存。 */
+export function _resetSkillsDirCache(): void { _cachedDir = undefined; }
+
+function parseSkillFile(content: string, name: string): SkillDefinition {
+  const m = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+  if (!m) return { name, description: '', body: content.trim() };
+  const fm: Record<string, string> = {};
+  for (const line of m[1].split('\n')) {
+    const i = line.indexOf(':');
+    if (i > 0 && /^[a-zA-Z_]+$/.test(line.slice(0, i).trim())) {
+      fm[line.slice(0, i).trim()] = line.slice(i + 1).trim().replace(/^["']|["']$/g, '');
+    }
+  }
+  return { name: fm.name || name, description: fm.description || '', body: m[2].trim() };
+}
+
+/** 加载一个 skill；找不到返回 null（不抛错）。 */
+export function loadSkill(name: string, dir = resolveSkillsDir()): SkillDefinition | null {
+  if (!dir) return null;
+  // 防路径穿越
+  if (/[^a-zA-Z0-9_-]/.test(name)) return null;
+  const file = join(dir, name, 'SKILL.md');
+  if (!existsSync(file)) return null;
+  try { return parseSkillFile(readFileSync(file, 'utf-8'), name); } catch { return null; }
+}
+
+/** 列出所有可用 skill。 */
+export function listSkills(dir = resolveSkillsDir()): SkillDefinition[] {
+  if (!dir || !existsSync(dir)) return [];
+  const out: SkillDefinition[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry.startsWith('.')) continue;
+    const skillFile = join(dir, entry, 'SKILL.md');
+    try {
+      if (statSync(join(dir, entry)).isDirectory() && existsSync(skillFile)) {
+        out.push(parseSkillFile(readFileSync(skillFile, 'utf-8'), entry));
+      }
+    } catch { /* skip */ }
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** 把 step 的 skill / skills 字段归一成名字数组。 */
+export function collectSkillNames(step: { skill?: string; skills?: string[] }): string[] {
+  const out: string[] = [];
+  if (step.skill) out.push(step.skill);
+  if (Array.isArray(step.skills)) out.push(...step.skills);
+  return [...new Set(out.filter(Boolean))];
+}
+
+/**
+ * 把指定 skill 的方法论追加到 system prompt 末尾。找不到的 skill 跳过（返回 missing 名单）。
+ * 不抛错——skills 是可选增强。
+ */
+export function injectSkills(systemPrompt: string, names: string[], dir = resolveSkillsDir()): { prompt: string; applied: string[]; missing: string[] } {
+  const applied: string[] = [];
+  const missing: string[] = [];
+  const blocks: string[] = [];
+  for (const n of names) {
+    const sk = loadSkill(n, dir);
+    if (!sk) { missing.push(n); continue; }
+    applied.push(sk.name);
+    blocks.push(`## 工作方法 / Skill：${sk.name}\n（完成本步骤时请严格遵循以下方法论）\n\n${sk.body}`);
+  }
+  if (!blocks.length) return { prompt: systemPrompt, applied, missing };
+  const prompt = `${systemPrompt}\n\n---\n\n${blocks.join('\n\n---\n\n')}`;
+  return { prompt, applied, missing };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,8 @@ export interface StepDefinition {
   emoji?: string;             // 自定义 emoji（覆盖角色文件的 emoji）
   task: string;               // 任务描述，支持 {{变量}} 模板
   output?: string;            // 输出变量名
+  skill?: string;             // 给本步挂一个方法论 skill（注入 system prompt），如 "test-driven-development"
+  skills?: string[];          // 多个 skill（与 skill 合并）
   depends_on?: string[];      // 依赖的步骤 id
   type?: 'normal' | 'approval' | 'human_input'; // 节点类型
   prompt?: string;            // approval / human_input 类型的提示文本

--- a/test/skills.ts
+++ b/test/skills.ts
@@ -1,0 +1,57 @@
+/**
+ * 测试 skills（流程剧本）加载 + 注入。内容来自依赖 superpowers-zh。
+ */
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  resolveSkillsDir, listSkills, loadSkill, collectSkillNames, injectSkills, _resetSkillsDirCache,
+} from '../src/skills/loader.js';
+
+let passed = 0, failed = 0;
+function assert(c: boolean, m: string): void { if (c) { console.log(`  ✅ ${m}`); passed++; } else { console.log(`  ❌ ${m}`); failed++; } }
+
+console.log('\n─── skills（流程剧本）───');
+
+// 用一个临时 skill 目录(不依赖 superpowers-zh 是否在位)，通过 AO_SKILLS_DIR 指过去
+const dir = mkdtempSync(join(tmpdir(), 'ao-skills-'));
+mkdirSync(join(dir, 'tdd'));
+writeFileSync(join(dir, 'tdd', 'SKILL.md'), `---
+name: tdd
+description: 测试驱动开发方法论
+---
+# TDD
+先写测试，再写实现，红-绿-重构。
+`, 'utf-8');
+mkdirSync(join(dir, 'bad-name!'), { recursive: true }); // 非法名，应被忽略
+
+process.env.AO_SKILLS_DIR = dir;
+_resetSkillsDirCache();
+
+assert(resolveSkillsDir() === dir, 'AO_SKILLS_DIR 解析生效');
+assert(listSkills().some(s => s.name === 'tdd'), 'listSkills 列出 tdd');
+
+const sk = loadSkill('tdd');
+assert(sk !== null && sk!.description === '测试驱动开发方法论', 'loadSkill 解析 frontmatter');
+assert(sk !== null && sk!.body.includes('红-绿-重构'), 'loadSkill 取到正文');
+assert(loadSkill('不存在') === null, '缺失 skill 返回 null（不抛错）');
+assert(loadSkill('../etc/passwd') === null, '非法名拒绝（防穿越）');
+
+assert(JSON.stringify(collectSkillNames({ skill: 'a', skills: ['b', 'a'] })) === JSON.stringify(['a', 'b']), 'collectSkillNames 合并去重');
+
+const inj = injectSkills('你是角色X。', ['tdd', '不存在']);
+assert(inj.prompt.includes('你是角色X。') && inj.prompt.includes('红-绿-重构'), 'injectSkills 把方法论追加到 system prompt');
+assert(inj.applied.includes('tdd') && inj.missing.includes('不存在'), 'injectSkills 报告 applied / missing');
+
+const none = injectSkills('原样', []);
+assert(none.prompt === '原样', '空 skills 不改 prompt');
+
+// 还原
+delete process.env.AO_SKILLS_DIR;
+_resetSkillsDirCache();
+// superpowers-zh 作为依赖应能解析到（CI 装了依赖）
+const real = resolveSkillsDir();
+assert(real === null || listSkills(real).length >= 0, '默认解析不抛错（有依赖则能列出）');
+
+console.log(`\n  结果: ${passed} 通过, ${failed} 失败\n`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
按定的「窄 MVP」做 skills,**内容直接用开源 superpowers-zh,不自己写**。

## 机制
角色=谁做,skill=怎么做。工作流步骤加 `skill: "<名字>"`(或 `skills: [..]`),运行时把该 skill 的方法论(流程剧本)注入这一步的 system prompt。
```yaml
- id: review
  role: "engineering/engineering-code-reviewer"
  skill: "chinese-code-review"
  task: "审查 {{code}}"
```

## 来源(用开源,零配置)
- 加 **superpowers-zh**(MIT,20 个 skill)为依赖 → `node_modules/superpowers-zh/skills` 开箱可用,我不写任何 skill 内容
- `AO_SKILLS_DIR` 可换成自己的 skill 目录
- 解析优先级:AO_SKILLS_DIR > ./skills > sibling/installed superpowers-zh

## CLI
`ao skills` 列出全部、`ao skills <名字>` 看方法论正文。

## 安全/健壮
缺失的 skill 跳过 + warn(不报错);skill 名做了防路径穿越。

## 测试
- `test/skills.ts`(11 项,解析/列举/注入/缺失/防穿越)并入 `npm test`,全套绿
- **真实 DeepSeek e2e**:带 `skill:` 的步骤打印「🧠 挂载 skill」并正常完成
- 19 个工作流模板 fixture 仍全部 validate 通过