### PR TITLE
feat: 新增 Agnes AI provider (OpenAI 兼容)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **`ao prompt` 文档补齐**：Prompt Lab 合入后 `ao prompt` 一直没进 `ao --help` / README / CLAUDE.md，用户无从发现；现已补上（中英）。
 
 ### Added
+- **新增 Agnes AI provider**：OpenAI 兼容(`apihub.agnes-ai.com/v1`,模型 `agnes-2.0-flash` 等)。`--provider agnes` 即可用,key 走 `AGNES_API_KEY` 环境变量 / Studio 配置(**不在仓库或前端写死**)。Studio 供应商面板、`ao init --provider agnes` 均已接入。
 - **Skills(给步骤挂方法论)**：工作流步骤可加 `skill: "<名字>"`(或 `skills: [..]`)，把「怎么做」的方法论(流程剧本)注入该步的 system prompt——角色决定谁做、skill 决定怎么做。内容直接用开源 **superpowers-zh**(MIT,20 个,已作为依赖,零配置);`AO_SKILLS_DIR` 可换成自己的。`ao skills [名字]` 列出 / 查看;缺失的 skill 跳过不报错。
 - **固定全局目录 `AO_HOME`**（#20）：设 `AO_HOME=~/.ao`（或任意目录）后，运行产物 `ao-output` 与 `compose`/`--team` 生成的工作流统一落到该目录，不再随执行目录散落；也可用 `AO_OUTPUT_DIR` / `AO_WORKFLOWS_DIR` 单独指定。**默认不设时维持原行为**（写到当前目录），向后兼容。团队 / 提示词 / 版本检查一直在 `~/.ao`。
 - **团队 / Loadout（可复用角色阵容）**：把跑得好的角色阵容存下来，套到任意新任务上。

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -319,7 +319,7 @@ async function handleCompose(): Promise<void> {
 
   const provider = (getArgValue('--provider') || process.env.AO_PROVIDER || 'deepseek') as LLMConfig['provider'];
   const cliProviders = ['claude-code', 'gemini-cli', 'copilot-cli', 'codex-cli', 'openclaw-cli', 'hermes-cli'];
-  const knownApiProviders = ['deepseek', 'claude', 'openai', 'ollama'];
+  const knownApiProviders = ['deepseek', 'claude', 'openai', 'ollama', 'agnes', 'apinebula', 'compshare'];
   const isUnknownProvider = !cliProviders.includes(provider) && !knownApiProviders.includes(provider);
   const cliModel = getArgValue('--model') || process.env.AO_MODEL;
   // 未知 provider（如 zhipu/qwen/moonshot 走 openai-compatible）必须显式指定 model，
@@ -332,6 +332,7 @@ async function handleCompose(): Promise<void> {
     cliProviders.includes(provider) ? '' :
     provider === 'deepseek' ? 'deepseek-chat' :
     provider === 'claude' ? 'claude-sonnet-4-20250514' :
+    provider === 'agnes' ? 'agnes-2.0-flash' :
     'gpt-4o'
   );
   const baseUrl = getArgValue('--base-url') || getArgValue('--baseurl');
@@ -488,6 +489,7 @@ function resolveProviderModel(teamProvider?: string, teamModel?: string): { prov
     provider === 'deepseek' ? 'deepseek-chat' :
     provider === 'claude' ? 'claude-sonnet-4-20250514' :
     provider === 'openai' ? 'gpt-4o' :
+    provider === 'agnes' ? 'agnes-2.0-flash' :
     ''
   );
   return { provider, model };
@@ -718,7 +720,8 @@ async function handlePrompt(): Promise<void> {
     cliProviders.includes(provider) ? '' :
     provider === 'deepseek' ? 'deepseek-chat' :
     provider === 'claude' ? 'claude-sonnet-4-20250514' :
-    provider === 'openai' ? 'gpt-4o' : ''
+    provider === 'openai' ? 'gpt-4o' :
+    provider === 'agnes' ? 'agnes-2.0-flash' : ''
   );
 
   try {
@@ -942,6 +945,7 @@ async function handleInit(): Promise<void> {
         p === 'deepseek' ? 'DEEPSEEK_BASE_URL' :
         p === 'compshare' ? 'COMPSHARE_BASE_URL' :
         p === 'apinebula' ? 'APINEBULA_BASE_URL' :
+        p === 'agnes' ? 'AGNES_BASE_URL' :
         'OPENAI_BASE_URL';
       updates[urlVar] = cfgBaseUrl;
     }
@@ -956,6 +960,7 @@ async function handleInit(): Promise<void> {
         p === 'anthropic' || p === 'claude' ? 'ANTHROPIC_API_KEY' :
         p === 'compshare' ? 'COMPSHARE_API_KEY' :
         p === 'apinebula' ? 'APINEBULA_API_KEY' :
+        p === 'agnes' ? 'AGNES_API_KEY' :
         'OPENAI_API_KEY';
       updates[keyVar] = cfgApiKey;
     }

--- a/src/connectors/factory.ts
+++ b/src/connectors/factory.ts
@@ -59,6 +59,13 @@ export function createConnector(config: LLMConfig): LLMConnector {
         apiKey: config.api_key || process.env.APINEBULA_API_KEY,
         baseUrl: config.base_url || process.env.APINEBULA_BASE_URL || 'https://apinebula.com/v1',
       });
+    case 'agnes':
+      // Agnes AI —— OpenAI 兼容,base_url 写死;模型如 agnes-2.0-flash / agnes-1.5-flash。
+      // key 只从 env / 配置读,绝不在代码里写死(写死=随包公开,免费额度会被刷爆)。
+      return new OpenAICompatibleConnector({
+        apiKey: config.api_key || process.env.AGNES_API_KEY,
+        baseUrl: config.base_url || process.env.AGNES_BASE_URL || 'https://apihub.agnes-ai.com/v1',
+      });
     default:
       // 未知 provider：如果提供了 base_url，当作 OpenAI 兼容 API 处理
       if (config.base_url) {

--- a/web/server.js
+++ b/web/server.js
@@ -76,6 +76,7 @@ function buildLLMConfig(provider) {
     : p === 'claude' ? 'claude-sonnet-4-20250514'
     : p === 'openai' ? 'gpt-4o'
     : p === 'apinebula' ? 'gpt-5.5'
+    : p === 'agnes' ? 'agnes-2.0-flash'
     : undefined; // ollama / custom: model must come from saved config
   const model = saved.model || defModel;
   if (model) cfg.model = model;
@@ -101,6 +102,8 @@ const KEY_ENV = {
   compshare: { key: 'COMPSHARE_API_KEY', base: 'COMPSHARE_BASE_URL' },
   // APINEBULA（旗舰赞助商）—— OpenAI 兼容，base 默认 apinebula.com/v1，用户只需填 key + 模型
   apinebula: { key: 'APINEBULA_API_KEY', base: 'APINEBULA_BASE_URL' },
+  // Agnes AI —— OpenAI 兼容,base 默认 apihub.agnes-ai.com/v1,模型如 agnes-2.0-flash
+  agnes: { key: 'AGNES_API_KEY', base: 'AGNES_BASE_URL' },
 };
 function readKeys() {
   try { return JSON.parse(readFileSync(KEYS_FILE, 'utf-8')) || {}; } catch { return {}; }

--- a/website/src/components/studio/ProvidersPanel.tsx
+++ b/website/src/components/studio/ProvidersPanel.tsx
@@ -12,6 +12,7 @@ const API_META: ApiMeta[] = [
   { id: "apinebula", name: "APINEBULA", hint: "apinebula.com", flagship: true },
   // 普通赞助商 CompShare —— 次于旗舰，中性「赞助商」标记
   { id: "compshare", name: "CompShare", hint: "console.compshare.cn", sponsor: true },
+  { id: "agnes", name: "Agnes AI", hint: "agnes-2.0-flash · agnes-ai.com" },
   { id: "deepseek", name: "DeepSeek", hint: "platform.deepseek.com" },
   { id: "openai", name: "OpenAI", hint: "gpt-4o {etc} · platform.openai.com" },
   { id: "claude", name: "Claude (Anthropic)", hint: "console.anthropic.com" },

--- a/website/src/lib/studio.ts
+++ b/website/src/lib/studio.ts
@@ -328,13 +328,14 @@ export function runRole(
 // 默认 provider：旗舰赞助商 APINEBULA（取代原来的 DeepSeek 默认）
 export const DEFAULT_PROVIDER = "apinebula";
 
-export const PROVIDERS = ["apinebula", "compshare", "deepseek", "openai", "claude", "claude-code", "gemini-cli", "openclaw-cli", "ollama"];
+export const PROVIDERS = ["apinebula", "compshare", "agnes", "deepseek", "openai", "claude", "claude-code", "gemini-cli", "openclaw-cli", "ollama"];
 
 // 仅品牌名（语言无关）。
 export const PROVIDER_LABELS: Record<string, string> = {
   apinebula: "APINEBULA",
   deepseek: "DeepSeek",
   compshare: "CompShare",
+  agnes: "Agnes AI",
   openai: "OpenAI",
   claude: "Claude",
   "claude-code": "Claude Code CLI",

--- a/website/src/pages/Studio.tsx
+++ b/website/src/pages/Studio.tsx
@@ -23,7 +23,7 @@ const UsagePanel = lazy(() => import("@/components/studio/UsagePanel").then((m) 
 
 // 需要 API key 的 provider。apinebula 是当前默认 provider，必须在列——否则新用户没填 key 时
 // 不会弹「需要配置 key」提示，直接运行才报认证错（commit 61e84a6 改默认后遗漏）。
-const KEYED = ["apinebula", "deepseek", "compshare", "openai", "claude"];
+const KEYED = ["apinebula", "deepseek", "compshare", "agnes", "openai", "claude"];
 
 type Tab = "roles" | "workflows" | "prompt" | "runs" | "usage" | "providers";
 


### PR DESCRIPTION
把 Agnes AI 接成一个 provider(OpenAI 兼容,`apihub.agnes-ai.com/v1`,模型 `agnes-2.0-flash` 等)。

- `--provider agnes` 即可用;key 走 `AGNES_API_KEY` 环境变量 / Studio 配置
- **安全**:key **绝不写进仓库或前端 bundle**(公开站静态前端塞 key = 公开即被刷爆)。代码只从 env/配置读。
- 接入面:factory 连接器、compose/run/--team/prompt 默认模型、`ao init --provider agnes` 路由、web 服务 `KEY_ENV` + 默认模型、Studio provider 下拉与供应商面板卡片
- 真实验证:`ao compose --run --provider agnes` 跑通 4 步工作流并出结果;全套 `npm test` 绿;扫描确认 key 未泄漏进任何文件

> 「官网免费可用」需另行部署:把 `AGNES_API_KEY` 设为**服务端密钥**(部署 `ao web` 后端或一个代理时的 env)+ 加限流,前端只调你的后端。key 不进 git。