### PR TITLE
fix(web): 模型选择改胶囊 + Prompt Lab 演示选模型 + CF 白名单

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **`ao prompt` 文档补齐**：Prompt Lab 合入后 `ao prompt` 一直没进 `ao --help` / README / CLAUDE.md，用户无从发现；现已补上（中英）。
 
 ### Added
+- **模型选择改成主题一致的「胶囊」**：供应商面板原生 datalist 下拉在深色主题下很丑,改为可点胶囊(点选 + 仍可手敲);Prompt Lab 演示站新增文本模型切换(agnes-2.0-flash / agnes-1.5-flash)。CF 函数接收前端选的模型并做**白名单校验**(只允许 Agnes 文本模型,非法/图像模型回落默认),防刷额度。
 - **供应商面板模型可选可填**：原来模型名只能手敲、易写错;现在每个 provider 给常用模型下拉建议(datalist),既能**选**也能**填**自定义,留空用默认。
 - **顶部导航新增「提示词优化」入口**(挨着「专家库」、在「文档」左边)→ 独立 `/prompt` 页,直接用提示词优化(公开站走 CF Function 免费额度)。撤销上一版把 Studio 内 tab 挪位的改动(那不是诉求)。
 - **公开站提示词优化免费可用(Cloudflare)**：新增 CF Pages Functions(`/api/prompt/optimize|test`)把提示词优化/测试代理到 Agnes,**key 作 CF 机密、不进前端/git**;静态演示站的「提示词」页因此可真实使用(单次 LLM 调用),完整工作流仍需本地。「提示词」tab 移到「角色组队」旁边方便取用。配置见 `website/functions/README.md`。

--- a/website/functions/api/prompt/optimize.js
+++ b/website/functions/api/prompt/optimize.js
@@ -32,6 +32,10 @@ export async function onRequestPost({ request, env }) {
   const mode = body?.mode === "system" ? "system" : "user";
   const lang = /[一-鿿]/.test(raw) ? "zh" : "en";
   const base = (env.AGNES_BASE_URL || "https://apihub.agnes-ai.com/v1").replace(/\/+$/, "");
+  // 模型：前端可选,但只接受白名单内的 Agnes 文本模型(防止请求贵模型刷额度)
+  const ALLOWED = ["agnes-2.0-flash", "agnes-1.5-flash"];
+  const reqModel = String(body?.model || "");
+  const model = ALLOWED.includes(reqModel) ? reqModel : (env.AGNES_MODEL || "agnes-2.0-flash");
 
   let res;
   try {
@@ -39,7 +43,7 @@ export async function onRequestPost({ request, env }) {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${key}` },
       body: JSON.stringify({
-        model: env.AGNES_MODEL || "agnes-2.0-flash",
+        model,
         messages: [{ role: "system", content: metaPrompt(mode, lang) }, { role: "user", content: raw }],
         max_tokens: 2048,
       }),

--- a/website/functions/api/prompt/test.js
+++ b/website/functions/api/prompt/test.js
@@ -20,13 +20,16 @@ export async function onRequestPost({ request, env }) {
   const system = mode === "system" ? prompt : "You are a helpful assistant.";
   const user = mode === "system" ? (testInput || "（请按你的设定给一个示例回应）") : (testInput ? `${prompt}\n\n---\n${testInput}` : prompt);
   const base = (env.AGNES_BASE_URL || "https://apihub.agnes-ai.com/v1").replace(/\/+$/, "");
+  const ALLOWED = ["agnes-2.0-flash", "agnes-1.5-flash"];
+  const reqModel = String(body?.model || "");
+  const model = ALLOWED.includes(reqModel) ? reqModel : (env.AGNES_MODEL || "agnes-2.0-flash");
 
   let res;
   try {
     res = await fetch(`${base}/chat/completions`, {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${key}` },
-      body: JSON.stringify({ model: env.AGNES_MODEL || "agnes-2.0-flash", messages: [{ role: "system", content: system }, { role: "user", content: user }], max_tokens: 2048 }),
+      body: JSON.stringify({ model, messages: [{ role: "system", content: system }, { role: "user", content: user }], max_tokens: 2048 }),
     });
   } catch (e) {
     return json({ error: "upstream fetch failed: " + (e?.message || e) }, 502);

--- a/website/src/components/studio/PromptLab.tsx
+++ b/website/src/components/studio/PromptLab.tsx
@@ -43,6 +43,9 @@ export function PromptLab({ provider, demo, onInstallPrompt }: { provider: strin
   const L = STR[lang === "en" ? "en" : "zh"];
 
   const [mode, setMode] = useState<PromptMode>("user");
+  // 演示站(免费额度走 CF Function 代理 Agnes)可选文本模型；本地用配好的 provider，不显示。
+  const DEMO_MODELS = ["agnes-2.0-flash", "agnes-1.5-flash"];
+  const [model, setModel] = useState(DEMO_MODELS[0]);
   const [raw, setRaw] = useState("");
   const [optimized, setOptimized] = useState<string | null>(null);
   const [optimizing, setOptimizing] = useState(false);
@@ -81,7 +84,7 @@ export function PromptLab({ provider, demo, onInstallPrompt }: { provider: strin
     if (!raw.trim()) { setErr(L.needRaw); return; }
     setOptimizing(true); setErr(null); setScore(null); setOuts({});
     try {
-      const { optimized: opt } = await api.optimizePrompt({ rawPrompt: raw.trim(), mode, provider, lang });
+      const { optimized: opt } = await api.optimizePrompt({ rawPrompt: raw.trim(), mode, provider, lang, model: demo ? model : undefined });
       setOptimized(opt);
     } catch (e: any) {
       if (demo) onInstallPrompt?.();
@@ -95,7 +98,7 @@ export function PromptLab({ provider, demo, onInstallPrompt }: { provider: strin
       const targets: [keyof typeof outs, string][] = [["original", raw.trim()]];
       if (optimized) targets.push(["optimized", optimized]);
       const results = await Promise.all(
-        targets.map(([, p]) => api.testPrompt({ prompt: p, mode, testInput: testInput.trim(), provider })),
+        targets.map(([, p]) => api.testPrompt({ prompt: p, mode, testInput: testInput.trim(), provider, model: demo ? model : undefined })),
       );
       const next: typeof outs = {};
       targets.forEach(([k], i) => { next[k] = results[i].output; });
@@ -183,6 +186,17 @@ export function PromptLab({ provider, demo, onInstallPrompt }: { provider: strin
               </button>
             ))}
           </div>
+          {/* 演示站可选模型（免费额度走 Agnes）；本地用配好的 provider，不显示 */}
+          {demo && (
+            <div className="inline-flex rounded-lg bg-muted/60 p-0.5">
+              {DEMO_MODELS.map((m) => (
+                <button key={m} onClick={() => setModel(m)} title={m}
+                  className={cn("rounded-md px-2.5 py-1 text-xs font-medium transition-colors", model === m ? "bg-background text-primary shadow-sm" : "text-muted-foreground")}>
+                  {m.replace(/^agnes-/, "").replace(/-flash$/, "")}
+                </button>
+              ))}
+            </div>
+          )}
           <div className="relative">
             <Button size="sm" variant="ghost" onClick={() => setShowGarden((v) => !v)}><Sprout className="size-4" />{L.garden}</Button>
             {showGarden && gardenForMode.length > 0 && (

--- a/website/src/components/studio/ProvidersPanel.tsx
+++ b/website/src/components/studio/ProvidersPanel.tsx
@@ -191,16 +191,28 @@ function ApiCard({
           value={model}
           onChange={(e) => setModel(e.target.value)}
           placeholder={t.studio.providers.modelPlaceholder}
-          list={`models-${meta.id}`}
           autoComplete="off"
           className="h-9 rounded-xl border border-border/70 bg-background px-3 text-sm outline-none focus:border-primary/50"
         />
-        <datalist id={`models-${meta.id}`}>
-          {(MODEL_SUGGESTIONS[meta.id] ?? []).map((m) => (
-            <option key={m} value={m} />
-          ))}
-        </datalist>
       </div>
+      {/* 常用模型「胶囊」：点一下填入,也可在上面手敲。主题一致,不用原生 datalist(深色下很丑)。 */}
+      {(MODEL_SUGGESTIONS[meta.id] ?? []).length > 0 && (
+        <div className="mt-1.5 flex flex-wrap gap-1.5">
+          {MODEL_SUGGESTIONS[meta.id].map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setModel(m)}
+              className={cn(
+                "rounded-full border px-2.5 py-0.5 text-xs transition-colors",
+                model === m ? "border-primary bg-primary/10 text-primary" : "border-border/70 text-muted-foreground hover:border-primary/40 hover:text-foreground",
+              )}
+            >
+              {m}
+            </button>
+          ))}
+        </div>
+      )}
 
       <div className="mt-3 flex items-center gap-3">
         <TestRow provider={meta.id} enabled={!!status?.hasKey} />

--- a/website/src/lib/studio.ts
+++ b/website/src/lib/studio.ts
@@ -237,9 +237,9 @@ export const api = {
   runInput: (runId: string, text: string) =>
     postJSON<{ ok: boolean }>("/run-input", { runId, text }),
   // ── Prompt Lab ──
-  optimizePrompt: (body: { rawPrompt: string; mode: PromptMode; provider?: string; lang?: string }) =>
+  optimizePrompt: (body: { rawPrompt: string; mode: PromptMode; provider?: string; lang?: string; model?: string }) =>
     postJSON<{ optimized: string }>("/prompt/optimize", body),
-  testPrompt: (body: { prompt: string; mode: PromptMode; testInput: string; provider?: string }) =>
+  testPrompt: (body: { prompt: string; mode: PromptMode; testInput: string; provider?: string; model?: string }) =>
     postJSON<{ output: string }>("/prompt/test", body),
   scorePrompts: (body: { testInput: string; candidates: { label: string; output: string }[]; provider?: string; lang?: string }) =>
     postJSON<ScoreResult>("/prompt/score", body),


### PR DESCRIPTION
## 起因
原生 `datalist` 下拉在深色主题下显示很怪(用户反馈)。

## 改动
- **供应商面板**:`datalist` → 主题一致的可点**胶囊**;点选填入,也仍可在输入框手敲。「填+选」都支持且不出戏。
- **Prompt Lab(演示站)**:新增文本模型切换(`agnes-2.0-flash` / `agnes-1.5-flash`),选了传给后端;本地用配好的 provider,不显示。
- **CF 函数**:`optimize`/`test` 接收前端 `model`,但做**白名单校验**——只允许 Agnes 文本模型,非法/图像/视频模型一律回落默认,防止有人请求贵模型刷免费额度。

## 说明
`agnes-2.0-flash` / `agnes-1.5-flash` 是 Agnes 的**文本/对话**模型(实测对话正常);`agnes-image-*` / `agnes-video-*` 是图像/视频,跑文本工作流用不上,已排除。

构建通过;CF 函数用真实 Agnes 验证:白名单内模型生效,非法模型回落默认。