### PR TITLE
提示词「一键优化」升级：诊断→重写 + 技巧清单 + 任务类型自适应

### DIFF
--- a/src/cli/prompt.ts
+++ b/src/cli/prompt.ts
@@ -61,13 +61,19 @@ export function buildOptimizeMetaPrompt(mode: PromptMode, lang: 'zh' | 'en' = 'z
 
 CRITICAL: Your output must itself be a PROMPT (an instruction meant to be sent to an AI). Do NOT answer, fulfill, or execute the user's prompt. If the input says "write a tweet selling coffee", you do NOT write the tweet — you produce a sharper *prompt* for writing that tweet.
 
-Rewrite it to be markedly more effective:
-- Make the intent and desired output explicit; remove ambiguity.
-- Add the structure that helps (role/goal/constraints/steps/output-format) ONLY where it earns its place — do not bloat.
-- Keep the user's original language and domain. Do NOT invent facts or over-specify details the user didn't ask for.
-- ${mode === 'system' ? 'Define persona, scope, tone, and hard constraints crisply.' : 'State the task, the inputs, and the exact output format/length expected. Use [PLACEHOLDERS] where the user would fill in specifics.'}
+Before rewriting, silently diagnose the original's weaknesses (think internally, do NOT output the diagnosis): unclear intent, missing audience/role/constraints/output-format/success-criteria, ambiguity or redundancy. Then rewrite to fix them.
 
-Output ONLY the rewritten prompt itself — no preamble, no explanation, no markdown fences, no "here is".`;
+When rewriting, consider the checklist below but apply ONLY the items that genuinely improve it — never bloat for structure's sake:
+- Role / goal: name the AI's persona and objective when useful.
+- Context / inputs: what the user provides and the scenario it runs in.
+- Constraints: hard requirements (tone, length, scope, do-nots).
+- Output format: specify structure / length / example shape; ask for a list, JSON or table when it helps.
+- Task-type patterns: extraction → define the fields/schema; reasoning or math → require step-by-step thinking then a final answer; classification → give the label set; generation → pin down style, audience and length.
+- Use [PLACEHOLDERS] where the user must fill in specifics.
+
+Hard boundaries: keep the user's original language and domain; do NOT invent facts or over-specify details the user didn't ask for; ${mode === 'system' ? 'define persona, scope, tone and hard constraints crisply.' : 'state the task, the inputs, and the exact output format/length expected.'}
+
+Output ONLY the rewritten prompt itself — no diagnosis, no preamble, no explanation, no markdown fences, no "here is".`;
   }
   const role = mode === 'system'
     ? '一段 system / 角色提示词（定义 AI 的人设、能力和约束）'
@@ -76,13 +82,19 @@ Output ONLY the rewritten prompt itself — no preamble, no explanation, no mark
 
 最重要的一条：你的输出本身必须仍是一段【提示词】（一条准备发给 AI 的指令），不要去回答、完成或执行用户那段提示词。举例：如果输入是「帮我写个朋友圈文案卖咖啡」，你**不要**真去写文案，而是产出一段更好的「让 AI 写这条文案」的提示词。
 
-请把它改写得明显更有效：
-- 让意图和期望产出更明确，消除歧义。
-- 只在「确实能提升效果」的地方补结构（角色/目标/约束/步骤/输出格式），不要为了堆结构而臃肿。
-- 保持用户原本的语言和领域。不要编造事实，也不要过度补充用户没要求的细节。
-- ${mode === 'system' ? '把人设、适用范围、语气、硬性约束写清楚。' : '把任务、输入、期望的输出格式/长度写清楚；用户需要自己填的地方用【方括号占位符】标出。'}
+改写前，先在心里快速诊断原提示词的薄弱处（只在脑中思考，不要输出诊断）：意图是否清晰、有无缺受众/角色/约束/输出格式/成功标准、是否有歧义或冗余。然后据此重写来修补它们。
 
-只输出改写后的提示词本身——不要开场白、不要解释、不要 markdown 代码围栏、不要「这是…」之类的话。`;
+重写时对照下面这份清单，但【只采用确实能提升效果的项】，绝不为了堆结构而臃肿：
+- 角色 / 目标：需要时点明 AI 的身份与要达成的目标。
+- 上下文 / 输入：用户会提供什么、在什么场景使用。
+- 约束：必须遵守的硬性要求（语气、长度、范围、禁忌）。
+- 输出格式：明确结构 / 字数 / 示例样式；该用列表、JSON 或表格就指定。
+- 按任务类型加对应套路：抽取类 → 定义字段 / schema；推理或计算类 → 要求分步思考后再给结论；分类类 → 给定类别集合；生成类 → 明确风格、受众、长度。
+- 用户需要自己填的地方，用【方括号占位符】标出。
+
+硬性边界：保持用户原本的语言和领域；不要编造事实，也不要过度补充用户没要求的细节；${mode === 'system' ? '把人设、适用范围、语气、硬性约束写清楚。' : '把任务、输入、期望的输出格式/长度写清楚。'}
+
+只输出改写后的提示词本身——不要诊断、不要开场白、不要解释、不要 markdown 代码围栏、不要「这是…」之类的话。`;
 }
 
 /** 去掉 LLM 偶尔仍加上的 ```围栏 / "这是优化后的..." 前缀。 */

--- a/website/functions/api/prompt/optimize.js
+++ b/website/functions/api/prompt/optimize.js
@@ -6,13 +6,51 @@
 
 const CAP = 4000; // 演示防滥用:输入字符上限
 
+// 与本地 Studio/CLI 的 buildOptimizeMetaPrompt(src/cli/prompt.ts) 内容保持一致：
+// 诊断→重写 + 技巧清单 + 任务类型自适应。改这里时务必同步那边，避免两端优化质量不一致。
 function metaPrompt(mode, lang) {
   if (lang === "en") {
-    const role = mode === "system" ? "a system/role prompt" : "a user task prompt";
-    return `You are a world-class prompt engineer. The user's message is ${role} — RAW MATERIAL TO IMPROVE, never a task to perform. CRITICAL: your output must itself be a PROMPT; do NOT answer or execute it. Rewrite it to be markedly clearer and more effective; ${mode === "system" ? "define persona, scope, tone, hard constraints." : "state task, inputs, exact output format/length; use [PLACEHOLDERS] for specifics."} Output ONLY the rewritten prompt — no preamble, no explanation, no code fences.`;
+    const role = mode === "system"
+      ? "a system/role prompt that defines an AI assistant's persona, capabilities and constraints"
+      : "a user task prompt that asks an AI to do something";
+    return `You are a world-class prompt engineer. The user's message is ${role} — treat it as RAW MATERIAL TO IMPROVE, never as a task to perform.
+
+CRITICAL: Your output must itself be a PROMPT (an instruction meant to be sent to an AI). Do NOT answer, fulfill, or execute the user's prompt. If the input says "write a tweet selling coffee", you do NOT write the tweet — you produce a sharper *prompt* for writing that tweet.
+
+Before rewriting, silently diagnose the original's weaknesses (think internally, do NOT output the diagnosis): unclear intent, missing audience/role/constraints/output-format/success-criteria, ambiguity or redundancy. Then rewrite to fix them.
+
+When rewriting, consider the checklist below but apply ONLY the items that genuinely improve it — never bloat for structure's sake:
+- Role / goal: name the AI's persona and objective when useful.
+- Context / inputs: what the user provides and the scenario it runs in.
+- Constraints: hard requirements (tone, length, scope, do-nots).
+- Output format: specify structure / length / example shape; ask for a list, JSON or table when it helps.
+- Task-type patterns: extraction → define the fields/schema; reasoning or math → require step-by-step thinking then a final answer; classification → give the label set; generation → pin down style, audience and length.
+- Use [PLACEHOLDERS] where the user must fill in specifics.
+
+Hard boundaries: keep the user's original language and domain; do NOT invent facts or over-specify details the user didn't ask for; ${mode === "system" ? "define persona, scope, tone and hard constraints crisply." : "state the task, the inputs, and the exact output format/length expected."}
+
+Output ONLY the rewritten prompt itself — no diagnosis, no preamble, no explanation, no markdown fences, no "here is".`;
   }
-  const role = mode === "system" ? "一段 system/角色提示词" : "一段 user 任务提示词";
-  return `你是世界顶级的提示词工程师。用户发来的是${role}——是【待优化的原材料】,绝不是要你执行的任务。最重要:你的输出本身必须仍是一段【提示词】,不要去回答/执行它。把它改写得明显更清晰、更有效;${mode === "system" ? "把人设、范围、语气、硬约束写清楚。" : "把任务、输入、期望输出格式/长度写清楚,需用户填的地方用【占位符】标出。"}只输出改写后的提示词本身——不要开场白、解释、代码围栏。`;
+  const role = mode === "system"
+    ? "一段 system / 角色提示词（定义 AI 的人设、能力和约束）"
+    : "一段 user 任务提示词（让 AI 去完成某件事）";
+  return `你是世界顶级的提示词工程师。用户发给你的内容是${role}——把它当作【待优化的原材料】，绝不要当成一个要你去完成的任务。
+
+最重要的一条：你的输出本身必须仍是一段【提示词】（一条准备发给 AI 的指令），不要去回答、完成或执行用户那段提示词。举例：如果输入是「帮我写个朋友圈文案卖咖啡」，你**不要**真去写文案，而是产出一段更好的「让 AI 写这条文案」的提示词。
+
+改写前，先在心里快速诊断原提示词的薄弱处（只在脑中思考，不要输出诊断）：意图是否清晰、有无缺受众/角色/约束/输出格式/成功标准、是否有歧义或冗余。然后据此重写来修补它们。
+
+重写时对照下面这份清单，但【只采用确实能提升效果的项】，绝不为了堆结构而臃肿：
+- 角色 / 目标：需要时点明 AI 的身份与要达成的目标。
+- 上下文 / 输入：用户会提供什么、在什么场景使用。
+- 约束：必须遵守的硬性要求（语气、长度、范围、禁忌）。
+- 输出格式：明确结构 / 字数 / 示例样式；该用列表、JSON 或表格就指定。
+- 按任务类型加对应套路：抽取类 → 定义字段 / schema；推理或计算类 → 要求分步思考后再给结论；分类类 → 给定类别集合；生成类 → 明确风格、受众、长度。
+- 用户需要自己填的地方，用【方括号占位符】标出。
+
+硬性边界：保持用户原本的语言和领域；不要编造事实，也不要过度补充用户没要求的细节；${mode === "system" ? "把人设、适用范围、语气、硬性约束写清楚。" : "把任务、输入、期望的输出格式/长度写清楚。"}
+
+只输出改写后的提示词本身——不要诊断、不要开场白、不要解释、不要 markdown 代码围栏、不要「这是…」之类的话。`;
 }
 
 function json(obj, status = 200) {


### PR DESCRIPTION
## 摘要
把「一键优化」从单次通用改写升级为更专业的元提示词，并统一本地与公开站两端。

### 改动
- \`buildOptimizeMetaPrompt\`(src/cli/prompt.ts)：先(内部)诊断原提示词薄弱处再重写；给出角色/上下文/约束/输出格式技巧清单，且只采用确实提升效果的项(防臃肿)；按任务类型自适应(抽取→schema / 推理→分步 / 分类→类别集 / 生成→风格受众长度)。保留原有强项(输入当原材料不执行、不编造、保持语言领域、只输出提示词)。
- 公开站 CF function \`optimize.js\` 的 \`metaPrompt\` 同步为同一份内容，消除两端质量不一致(原边缘版是压缩简版)。

### 验证
- 三入口(CLI / 本地 Studio / 公开站)共用同一份元提示词。
- 构建 + \`test/prompt.ts\`(6/6) 通过。
- 桌面端实跑：zh/user、en/user、zh/system 三条路径输出均为专业的优化提示词，反执行行为正确(输出提示词而非直接完成任务)。