### PR TITLE
Studio 中文显示「工作台」

### DIFF
--- a/website/src/i18n/translations.ts
+++ b/website/src/i18n/translations.ts
@@ -7,7 +7,7 @@ const zh = {
   nav: {
     home: "首页",
     features: "能力",
-    studio: "Studio",
+    studio: "工作台",
     experts: "专家库",
     prompt: "提示词优化",
     sponsors: "赞助商",

--- a/website/src/pages/Studio.tsx
+++ b/website/src/pages/Studio.tsx
@@ -88,7 +88,7 @@ function StudioInner() {
           <div className="container-page flex flex-wrap items-center gap-x-4 gap-y-2 py-3">
             <span className="flex items-center gap-2 font-bold">
               <span className="grid size-7 place-items-center rounded-lg bg-primary text-sm text-primary-foreground">ao</span>
-              Studio
+              {t.nav.studio}
             </span>
 
             {status !== "checking" && (


### PR DESCRIPTION
nav.studio 中文由 `Studio` 改为「工作台」（中文 SaaS 主工作区通用叫法，如阿里云/飞书工作台）；Studio 页内「ao Studio」徽标改用 `t.nav.studio` 不再硬编码。英文仍为 Studio。