### PR TITLE
aiOlaOla 署名改「配套学习」

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 > 📖 [完整上手教程](https://mp.weixin.qq.com/s/XcGbkMb6TM6NLQiL7ICwbw) — 从安装到实战，10 分钟上手
 >
-> 🌟 出品方 [aiOlaOla](https://aiolaola.com/) · 学 · 用 · 创造 AI — 一个账号解锁全部 AI 产品：180 节免费 AI 编程课 · 《方法论三卷书》· 实战社区
+> 📖 **配套学习**：[aiOlaOla — 学 · 用 · 创造 AI](https://aiolaola.com/) — 180 节免费 AI 编程课 + 《方法论三卷书》+ 实战社区 · 一个账号解锁全部 · 永久免费
 
 > 觉得有用？请点个 **Star** — 帮助更多人发现这个项目。
 

--- a/website/src/components/layout/SiteFooter.tsx
+++ b/website/src/components/layout/SiteFooter.tsx
@@ -56,7 +56,7 @@ export function SiteFooter() {
             </a>
           </p>
           <p className="mt-2 max-w-xs text-sm text-muted-foreground">
-            {lang === "zh" ? "出品方 " : "Part of "}
+            {lang === "zh" ? "配套学习 " : "Companion learning "}
             <a
               href={SITE.platform}
               target="_blank"


### PR DESCRIPTION
「出品方」偏硬，改为「配套学习」(README + 站点页脚)，与两个依赖仓口径一致。