### PR TITLE
aiOlaOla 配套学习文案统一（免费 + 统一书名）

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 > 📖 [完整上手教程](https://mp.weixin.qq.com/s/XcGbkMb6TM6NLQiL7ICwbw) — 从安装到实战，10 分钟上手
 >
-> 📖 **配套学习**：[aiOlaOla — 学 · 用 · 创造 AI](https://aiolaola.com/) — 180 节免费 AI 编程课 + 《方法论三卷书》+ 实战社区 · 一个账号解锁全部 · 永久免费
+> 📖 **免费配套学习** → [从零学会 AI 编程](https://aiolaola.com/)：180 节免费实操课 + 《AI 编程实战三卷书》在线阅读 + 实战社区 · 永久免费
 
 > 觉得有用？请点个 **Star** — 帮助更多人发现这个项目。
 

--- a/website/src/components/layout/SiteFooter.tsx
+++ b/website/src/components/layout/SiteFooter.tsx
@@ -56,16 +56,15 @@ export function SiteFooter() {
             </a>
           </p>
           <p className="mt-2 max-w-xs text-sm text-muted-foreground">
-            {lang === "zh" ? "配套学习 " : "Companion learning "}
+            {lang === "zh" ? "免费配套学习 " : "Free companion learning "}
             <a
               href={SITE.platform}
               target="_blank"
               rel="noreferrer"
               className="font-medium text-foreground underline-offset-2 hover:underline"
             >
-              aiOlaOla ↗
+              {lang === "zh" ? "从零学会 AI 编程 ↗" : "Learn AI coding from scratch ↗"}
             </a>
-            {lang === "zh" ? " · 学 · 用 · 创造 AI" : " · Learn · Use · Create AI"}
           </p>
           <a
             href={SITE.repo}


### PR DESCRIPTION
统一书名为《AI 编程实战三卷书》,措辞统一为「免费配套学习 → aiOlaOla：180 节免费实操课 + 三卷书在线阅读 + 实战社区」。README + 站点页脚。与其他三仓对齐。