### PR TITLE
Studio：多智能体 vs 单次基线 对比视图 (P0)

### DIFF
--- a/web/server.js
+++ b/web/server.js
@@ -493,6 +493,28 @@ app.post('/api/run-input', (req, res) => {
   }
 });
 
+// ── 多智能体 vs 单次基线对比（把 eval 的核心证明产品化）──
+// 需本地引擎(in-process 调 dist/index.js)；公开站无此能力。一次跑完返回 JSON(非流式)。
+app.post('/api/compare', async (req, res) => {
+  const { file, inputs, provider } = req.body || {};
+  if (!file || typeof file !== 'string') return res.status(400).json({ error: 'invalid workflow file' });
+  const resolvedFile = resolve(file);
+  if (!isAllowedWorkflow(resolvedFile)) return res.status(403).json({ error: 'file outside allowed dirs' });
+  if (!existsSync(resolvedFile)) return res.status(404).json({ error: 'workflow file not found' });
+  try {
+    const { compareWorkflowVsBaseline } = await import('../dist/index.js');
+    const llm = buildLLMConfig(provider); // key 已在启动时注入 process.env，connector 自取
+    const cmp = await compareWorkflowVsBaseline(resolvedFile, inputs || {}, {
+      quiet: true,
+      outputDir: OUTPUT_DIR,
+      genOverride: { provider: llm.provider, model: llm.model, base_url: llm.base_url },
+    });
+    res.json({ multiOutput: cmp.multiOutput, baselineOutput: cmp.baselineOutput, verdict: cmp.verdict });
+  } catch (err) {
+    res.status(500).json({ error: err?.message || String(err) });
+  }
+});
+
 // ── Roles / Agents ──
 const CATEGORY_NAMES = {
   zh: {

--- a/website/src/components/studio/BaselineCompareOverlay.tsx
+++ b/website/src/components/studio/BaselineCompareOverlay.tsx
@@ -1,0 +1,136 @@
+import { Loader2, Trophy, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useLanguage } from "@/i18n/LanguageProvider";
+import { Button } from "@/components/ui/button";
+import { api, type CompareResult, type Workflow } from "@/lib/studio";
+import { cn } from "@/lib/utils";
+import { Markdown } from "./Markdown";
+
+/**
+ * 多智能体 vs 单次基线 对比视图（把 EVAL_FINDINGS 的核心证明产品化）。
+ * 调 /api/compare：跑完整工作流 + 单次基线 + 双向盲评，并排展示 + 评审结论。
+ * 非流式——一次跑完返回，过程中显示 loading（可能一两分钟）。
+ */
+export function BaselineCompareOverlay({
+  wf,
+  inputs,
+  provider,
+  onClose,
+}: {
+  wf: Workflow;
+  inputs: Record<string, string>;
+  provider: string;
+  onClose: () => void;
+}) {
+  const { lang } = useLanguage();
+  const zh = lang !== "en";
+  const [state, setState] = useState<"running" | "done" | "error">("running");
+  const [result, setResult] = useState<CompareResult | null>(null);
+  const [err, setErr] = useState<string>("");
+  const started = useRef(false);
+
+  useEffect(() => {
+    if (started.current) return; // StrictMode 双调用守卫
+    started.current = true;
+    api
+      .compare({ file: wf.file, inputs, provider: provider || undefined })
+      .then((r) => {
+        setResult(r);
+        setState("done");
+      })
+      .catch((e) => {
+        setErr(e?.message || String(e));
+        setState("error");
+      });
+  }, [wf.file, inputs, provider]);
+
+  const v = result?.verdict;
+  const winnerLabel =
+    v?.winner === "multi-agent" ? (zh ? "✅ 多智能体胜" : "✅ Multi-agent wins")
+    : v?.winner === "baseline" ? (zh ? "❌ 单次基线胜" : "❌ Single-shot wins")
+    : (zh ? "➖ 打平" : "➖ Tie");
+
+  return (
+    <div className="fixed inset-0 z-[60] flex flex-col bg-black/50 backdrop-blur-sm">
+      <div className="flex items-center justify-between border-b border-border/60 bg-background px-5 py-3.5">
+        <h3 className="flex items-center gap-2 font-semibold">
+          <Trophy className="size-4 text-primary" />
+          {(zh ? "多智能体 vs 单次基线 · " : "Multi-agent vs Single-shot · ") + wf.name}
+        </h3>
+        <Button size="sm" variant="ghost" onClick={onClose}>
+          <X className="size-4" />
+        </Button>
+      </div>
+
+      {/* 评审横幅 */}
+      {state === "done" && (
+        <div className="border-b border-border/60 bg-background px-5 py-3">
+          {v ? (
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+              <span
+                className={cn(
+                  "rounded-full px-3 py-1 text-sm font-bold",
+                  v.winner === "multi-agent" ? "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400"
+                  : v.winner === "baseline" ? "bg-amber-500/15 text-amber-600 dark:text-amber-400"
+                  : "bg-muted text-muted-foreground",
+                )}
+              >
+                {winnerLabel}
+              </span>
+              <span className="text-sm text-muted-foreground">
+                {(zh ? "多智能体 " : "Multi-agent ")}<b className="text-foreground">{v.multiScore.toFixed(1)}</b>
+                {" · "}{(zh ? "单次基线 " : "Single-shot ")}<b className="text-foreground">{v.baseScore.toFixed(1)}</b>
+              </span>
+              <span className={cn("text-xs", v.consistent ? "text-muted-foreground" : "text-amber-600 dark:text-amber-400")}>
+                {v.consistent ? (zh ? "高可信" : "high confidence") : (zh ? "低可信（疑位置偏置）" : "low confidence (position bias)")}
+              </span>
+            </div>
+          ) : (
+            <p className="text-sm text-amber-600 dark:text-amber-400">
+              {zh ? "评审未给出可信评分（judge 解析失败），下面两份产出可人工对比。" : "Judge returned no reliable score; compare the two outputs below manually."}
+            </p>
+          )}
+          {v?.reasons?.length ? (
+            <ul className="mt-1.5 space-y-0.5">
+              {v.reasons.map((r, i) => (
+                <li key={i} className="text-xs text-muted-foreground">· {r}</li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      )}
+
+      {/* 内容 */}
+      <div className="flex flex-1 gap-4 overflow-auto bg-background p-5">
+        {state === "running" && (
+          <div className="m-auto flex flex-col items-center gap-3 text-muted-foreground">
+            <Loader2 className="size-6 animate-spin text-primary" />
+            <p className="max-w-sm text-center text-sm">
+              {zh
+                ? "对比中…正在跑完整多智能体工作流 + 单次基线 + 双向盲评，可能需要一两分钟。"
+                : "Comparing… running the full multi-agent workflow + single-shot baseline + blind judging. May take a minute or two."}
+            </p>
+          </div>
+        )}
+        {state === "error" && <p className="m-auto max-w-md text-center text-sm text-red-500">{err}</p>}
+        {state === "done" && result && (
+          <>
+            <Pane title={zh ? "多智能体（AO 工作流）" : "Multi-agent (AO workflow)"} highlight={v?.winner === "multi-agent"} text={result.multiOutput} empty={zh ? "（无产出）" : "(no output)"} />
+            <Pane title={zh ? "单次基线（一句话直接要成品）" : "Single-shot baseline"} highlight={v?.winner === "baseline"} text={result.baselineOutput} empty={zh ? "（无产出）" : "(no output)"} />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Pane({ title, text, highlight, empty }: { title: string; text: string; highlight?: boolean; empty: string }) {
+  return (
+    <div className={cn("flex min-w-[300px] flex-1 flex-col rounded-2xl border bg-card/60", highlight ? "border-primary ring-1 ring-primary/40" : "border-border/70")}>
+      <div className="border-b border-border/60 px-4 py-2.5 text-sm font-semibold">{title}</div>
+      <div className="flex-1 overflow-auto p-4">
+        {text ? <Markdown>{text}</Markdown> : <p className="text-sm text-muted-foreground">{empty}</p>}
+      </div>
+    </div>
+  );
+}

--- a/website/src/components/studio/WorkflowsPanel.tsx
+++ b/website/src/components/studio/WorkflowsPanel.tsx
@@ -1,4 +1,4 @@
-import { Check, GitCompare, Loader2, Play, Search, X } from "lucide-react";
+import { Check, GitCompare, Loader2, Play, Scale, Search, X } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useLanguage } from "@/i18n/LanguageProvider";
 import { Button } from "@/components/ui/button";
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import { RoleAvatar } from "./RoleAvatar";
 import type { RunRequest } from "./RunManager";
 import { CompareOverlay } from "./CompareOverlay";
+import { BaselineCompareOverlay } from "./BaselineCompareOverlay";
 
 function CastStack({ steps }: { steps: NonNullable<Workflow["steps"]> }) {
   const shown = steps.slice(0, 6);
@@ -30,8 +31,8 @@ function CastStack({ steps }: { steps: NonNullable<Workflow["steps"]> }) {
   );
 }
 
-function InputsDialog({ wf, provider, onClose, onRun }: { wf: Workflow; provider: string; onClose: () => void; onRun: (r: RunRequest) => void }) {
-  const { t } = useLanguage();
+function InputsDialog({ wf, provider, onClose, onRun, onCompare }: { wf: Workflow; provider: string; onClose: () => void; onRun: (r: RunRequest) => void; onCompare: (inputs: Record<string, string>) => void }) {
+  const { t, lang } = useLanguage();
   const inputs = wf.inputs ?? [];
   const [vals, setVals] = useState<Record<string, string>>(() => {
     const init: Record<string, string> = {};
@@ -41,6 +42,10 @@ function InputsDialog({ wf, provider, onClose, onRun }: { wf: Workflow; provider
 
   const submit = () => {
     onRun({ kind: "workflow", title: wf.name, file: wf.file, inputs: vals, provider: provider || undefined, cast: wf.steps });
+    onClose();
+  };
+  const compare = () => {
+    onCompare(vals);
     onClose();
   };
 
@@ -76,6 +81,10 @@ function InputsDialog({ wf, provider, onClose, onRun }: { wf: Workflow; provider
           <Button variant="ghost" onClick={onClose}>
             {t.studio.workflows.cancel}
           </Button>
+          <Button variant="outline" onClick={compare} title={lang === "en" ? "Run the workflow and a single-shot baseline, then blind-judge both" : "跑工作流 + 单次基线并盲评对比"}>
+            <Scale className="size-4" />
+            {lang === "en" ? "vs Single-shot" : "对比单次"}
+          </Button>
           <Button onClick={submit}>
             <Play className="size-4" />
             {t.studio.workflows.run}
@@ -95,6 +104,7 @@ export function WorkflowsPanel({ provider, onRun, demo, onInstallPrompt }: { pro
   const [picked, setPicked] = useState<Record<string, Workflow>>({});
   const [inputsFor, setInputsFor] = useState<Workflow | null>(null);
   const [compare, setCompare] = useState<Workflow[] | null>(null);
+  const [baseline, setBaseline] = useState<{ wf: Workflow; inputs: Record<string, string> } | null>(null);
 
   useEffect(() => {
     setLoading(true);
@@ -133,6 +143,13 @@ export function WorkflowsPanel({ provider, onRun, demo, onInstallPrompt }: { pro
     if (demo) return onInstallPrompt?.();
     if (w.inputs && w.inputs.length) setInputsFor(w);
     else onRun({ kind: "workflow", title: w.name, file: w.file, provider: provider || undefined, cast: w.steps });
+  };
+
+  // 对比单次基线：需引擎，demo 引导安装；有输入先填，再开对比视图
+  const compareOne = (w: Workflow) => {
+    if (demo) return onInstallPrompt?.();
+    if (w.inputs && w.inputs.length) setInputsFor(w); // 复用输入对话框（含「对比单次」按钮）
+    else setBaseline({ wf: w, inputs: {} });
   };
 
   if (loading)
@@ -190,10 +207,15 @@ export function WorkflowsPanel({ provider, onRun, demo, onInstallPrompt }: { pro
                   {`${w.steps?.length ?? 0} ${t.studio.workflows.steps}`}
                   {w.private ? ` · ${t.studio.workflows.mine}` : ""}
                 </span>
-                <Button size="sm" onClick={() => runOne(w)}>
-                  <Play className="size-3.5" />
-                  {t.studio.workflows.run}
-                </Button>
+                <div className="flex items-center gap-1.5">
+                  <Button size="sm" variant="ghost" onClick={() => compareOne(w)} title={lang === "en" ? "Compare vs single-shot" : "对比单次基线（看多智能体到底强在哪）"}>
+                    <Scale className="size-3.5" />
+                  </Button>
+                  <Button size="sm" onClick={() => runOne(w)}>
+                    <Play className="size-3.5" />
+                    {t.studio.workflows.run}
+                  </Button>
+                </div>
               </div>
             </div>
           );
@@ -220,8 +242,17 @@ export function WorkflowsPanel({ provider, onRun, demo, onInstallPrompt }: { pro
         </div>
       )}
 
-      {inputsFor && <InputsDialog wf={inputsFor} provider={provider} onClose={() => setInputsFor(null)} onRun={onRun} />}
+      {inputsFor && (
+        <InputsDialog
+          wf={inputsFor}
+          provider={provider}
+          onClose={() => setInputsFor(null)}
+          onRun={onRun}
+          onCompare={(inputs) => setBaseline({ wf: inputsFor, inputs })}
+        />
+      )}
       {compare && <CompareOverlay workflows={compare} provider={provider} onClose={() => setCompare(null)} />}
+      {baseline && <BaselineCompareOverlay wf={baseline.wf} inputs={baseline.inputs} provider={provider} onClose={() => setBaseline(null)} />}
     </div>
   );
 }

--- a/website/src/lib/studio.ts
+++ b/website/src/lib/studio.ts
@@ -212,6 +212,19 @@ export const PRICING: Record<string, { label: string; in: number; out: number }>
   gemini: { label: "Gemini 1.5 Pro", in: 1.25, out: 5 },
 };
 
+export interface CompareVerdict {
+  multiScore: number;
+  baseScore: number;
+  winner: "multi-agent" | "baseline" | "tie";
+  consistent: boolean;
+  reasons: string[];
+}
+export interface CompareResult {
+  multiOutput: string;
+  baselineOutput: string;
+  verdict: CompareVerdict | null;
+}
+
 export const api = {
   health: () => getJSON<{ ok: boolean; version: string }>("/health"),
   usage: () => getJSON<UsageResponse>("/usage"),
@@ -236,6 +249,9 @@ export const api = {
   // 把人工输入写回正在等待的运行（human_input / approval 节点暂停时）
   runInput: (runId: string, text: string) =>
     postJSON<{ ok: boolean }>("/run-input", { runId, text }),
+  // ── 多智能体 vs 单次基线对比（本地引擎，非流式，可能较慢）──
+  compare: (body: { file: string; inputs: Record<string, string>; provider?: string }) =>
+    postJSON<CompareResult>("/compare", body),
   // ── Prompt Lab ──
   optimizePrompt: (body: { rawPrompt: string; mode: PromptMode; provider?: string; lang?: string; model?: string }) =>
     postJSON<{ optimized: string }>("/prompt/optimize", body),


### PR DESCRIPTION
把 EVAL_FINDINGS 的核心证明产品化进 Studio（接 #70 的引擎/CLI 侧）。

## 改动
- `web/server.js`：`POST /api/compare`(in-process 调 `compareWorkflowVsBaseline`，本地引擎专属)。
- `BaselineCompareOverlay.tsx`：顶部 verdict 横幅(胜者/分数/可信度/理由) + 两栏产出。
- `WorkflowsPanel`：工作流卡片 + 输入框加「对比单次」入口。
- `studio.ts`：`api.compare` + 类型。

## 测试
- website 构建通过。
- `/api/compare` DeepSeek 实测端到端：返回多智能体/基线两份产出 + 双向盲评 verdict(含低可信标注)。