### PR TITLE
去重：删正文里重复的免费配套学习行（顶部标记块已有）

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@
 **一句话出结果 · 216 个专业 AI 角色 · YAML 零代码 · 10 种大模型 · 支持 key（推荐 DeepSeek），也有 7 种免 key 方式**
 
 > 📖 [完整上手教程](https://mp.weixin.qq.com/s/XcGbkMb6TM6NLQiL7ICwbw) — 从安装到实战，10 分钟上手
->
-> 📖 **免费配套学习** → [从零学会 AI 编程](https://aiolaola.com/)：180 节免费实操课 + 《AI 编程实战三卷书》在线阅读 + 实战社区 · 永久免费
 
 > 觉得有用？请点个 **Star** — 帮助更多人发现这个项目。
 


### PR DESCRIPTION
README 顶部 `aiolaola:start/end` 标记块已是正式版；正文里那条旧的同款「免费配套学习」行重复，删掉。仅删 1 处重复，标记块不动。