### PR TITLE
aiolaola 块从顶部移回正文

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,15 +1,5 @@
 # Agency Orchestrator
 
-
-
-
-<!-- aiolaola:start -->
-> 📖 **Free companion learning** · [aiOlaOla — Learn AI coding from zero →](https://aiolaola.com/?utm_source=github&utm_campaign=orchestrator)
-> 180 free hands-on lessons + the AI Coding Trilogy online + community + AI tutor · **Free forever, sign in to learn.**
->
-> 🌟 **Sister projects**: [agency-agents-zh ⭐15.2k](https://github.com/jnMetaCode/agency-agents-zh) · [superpowers-zh ⭐5.6k](https://github.com/jnMetaCode/superpowers-zh) · [ai-shortfilm-prompts](https://github.com/jnMetaCode/ai-shortfilm-prompts) · [ai-coding-trilogy](https://github.com/jnMetaCode/ai-coding-trilogy) · [ai-coding-guide ⭐405](https://github.com/jnMetaCode/ai-coding-guide)
-<!-- aiolaola:end -->
-
 **English** | [中文](./README.md)
 
 > **One sentence in, a full plan out — multiple AI roles collaborate automatically.**
@@ -24,6 +14,8 @@
 > **Note:** `ao compose --run` auto-detects your language. Both 216 Chinese roles and 184 English roles ([agency-agents](https://github.com/msitarzewski/agency-agents), MIT) are **bundled in the npm package — no extra download needed**. **10 English workflow templates** are ready in `workflows/en/`.
 
 > 📖 [Full Tutorial](https://dev.to/jnmetacode/agency-orchestrator-one-sentence-five-ai-agents-a-complete-plan-in-3-minutes-1ij6) — from install to real-world use in 10 minutes
+>
+> 📖 **Free companion learning** → [Learn AI coding from zero](https://aiolaola.com/): 180 free hands-on lessons + AI Coding Trilogy online + community · forever free
 
 > If you find this useful, please **Star** it — helps others discover the project.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,5 @@
 # Agency Orchestrator
 
-
-
-
-<!-- aiolaola:start -->
-> 📖 **免费配套学习** · [aiOlaOla — 从零学会 AI 编程 →](https://aiolaola.com/?utm_source=github&utm_campaign=orchestrator)
-> 180 节免费实操课 + 《AI 编程实战三卷书》在线读 + 实战社区 + AI 助教 · **永久免费,登录即学。**
->
-> 🌟 **姐妹项目**:[agency-agents-zh ⭐15.2k](https://github.com/jnMetaCode/agency-agents-zh) · [superpowers-zh ⭐5.6k](https://github.com/jnMetaCode/superpowers-zh) · [ai-shortfilm-prompts](https://github.com/jnMetaCode/ai-shortfilm-prompts) · [ai-coding-trilogy](https://github.com/jnMetaCode/ai-coding-trilogy) · [ai-coding-guide ⭐405](https://github.com/jnMetaCode/ai-coding-guide)
-<!-- aiolaola:end -->
-
 **中文** | [English](./README.en.md)
 
 > **一句话，让多个 AI 角色自动协作，几分钟出完整方案。**
@@ -22,6 +12,8 @@
 **一句话出结果 · 216 个专业 AI 角色 · YAML 零代码 · 10 种大模型 · 支持 key（推荐 DeepSeek），也有 7 种免 key 方式**
 
 > 📖 [完整上手教程](https://mp.weixin.qq.com/s/XcGbkMb6TM6NLQiL7ICwbw) — 从安装到实战，10 分钟上手
+>
+> 📖 **免费配套学习** → [从零学会 AI 编程](https://aiolaola.com/)：180 节免费实操课 + 《AI 编程实战三卷书》在线阅读 + 实战社区 · 永久免费
 
 > 觉得有用？请点个 **Star** — 帮助更多人发现这个项目。
 


### PR DESCRIPTION
顶部 `aiolaola:start/end` 块位于标题/徽标之前、太靠前压住项目介绍；去掉它，把「免费配套学习」放回正文(教程行之后)。README + README.en 一致。