### PR TITLE
Studio：工作流「开发项目」勾选 → 生成代码落盘

### DIFF
--- a/web/server.js
+++ b/web/server.js
@@ -312,7 +312,7 @@ const activeRuns = new Map();
 
 // ── Run workflow (with optional resume) ──
 app.post('/api/run', (req, res) => {
-  const { file, inputs, provider, resume, fromStep, feedback } = req.body || {};
+  const { file, inputs, provider, resume, fromStep, feedback, materialize } = req.body || {};
   if (!file || typeof file !== 'string') {
     return res.status(400).json({ error: 'invalid workflow file' });
   }
@@ -355,6 +355,12 @@ app.post('/api/run', (req, res) => {
   if (feedback && typeof feedback === 'string' && feedback.trim()) {
     if (fromStep && !resume) args.push('--from', fromStep);
     args.push('--feedback', feedback);
+  }
+  // 「开发项目」勾选：把开发步产出的文件块落盘到本地 scaffold 目录
+  if (materialize) {
+    const safe = basename(resolvedFile).replace(/\.ya?ml$/i, '').replace(/[^\w.一-龥-]+/g, '-');
+    const dest = join(DATA_DIR, 'scaffold', safe);
+    args.push('--materialize', dest);
   }
   for (const [k, v] of Object.entries(inputs || {})) {
     if (v !== '' && v !== undefined && v !== null) {

--- a/website/src/components/studio/RunManager.tsx
+++ b/website/src/components/studio/RunManager.tsx
@@ -36,6 +36,7 @@ export type RunRequest =
       fromStep?: string;
       feedback?: string;
       cast?: WorkflowStepMeta[];
+      materialize?: boolean;
     }
   | { kind: "role"; title: string; role: string; emoji?: string; name?: string; task: string; provider?: string; lang?: string };
 
@@ -208,7 +209,7 @@ export function RunProvider({ children }: { children: ReactNode }) {
       const starter =
         request.kind === "workflow"
           ? runWorkflow(
-              { file: request.file, inputs: request.inputs, provider: request.provider, resume: request.resume, fromStep: request.fromStep, feedback: request.feedback },
+              { file: request.file, inputs: request.inputs, provider: request.provider, resume: request.resume, fromStep: request.fromStep, feedback: request.feedback, materialize: request.materialize },
               onEvent,
               ctrl.signal,
             )

--- a/website/src/components/studio/WorkflowsPanel.tsx
+++ b/website/src/components/studio/WorkflowsPanel.tsx
@@ -39,9 +39,10 @@ function InputsDialog({ wf, provider, onClose, onRun, onCompare }: { wf: Workflo
     inputs.forEach((i) => (init[i.name] = i.default ?? ""));
     return init;
   });
+  const [materialize, setMaterialize] = useState(false);
 
   const submit = () => {
-    onRun({ kind: "workflow", title: wf.name, file: wf.file, inputs: vals, provider: provider || undefined, cast: wf.steps });
+    onRun({ kind: "workflow", title: wf.name, file: wf.file, inputs: vals, provider: provider || undefined, cast: wf.steps, materialize });
     onClose();
   };
   const compare = () => {
@@ -77,6 +78,17 @@ function InputsDialog({ wf, provider, onClose, onRun, onCompare }: { wf: Workflo
           ))}
           {!inputs.length && <p className="text-sm text-muted-foreground">{t.studio.workflows.noInputsNeeded}</p>}
         </div>
+        <label className="mt-4 flex cursor-pointer items-start gap-2 rounded-xl border border-border/70 bg-card/40 p-3">
+          <input type="checkbox" checked={materialize} onChange={(e) => setMaterialize(e.target.checked)} className="mt-0.5" />
+          <span className="text-sm">
+            <span className="font-medium">{lang === "en" ? "Develop project (write code to files)" : "开发项目（把生成的代码写成真实文件）"}</span>
+            <span className="mt-0.5 block text-xs text-muted-foreground">
+              {lang === "en"
+                ? "If the workflow produces code, save it as a runnable scaffold on disk. The run log shows where."
+                : "若工作流会产出代码，跑完落盘成可运行脚手架到本地；运行日志里显示路径。"}
+            </span>
+          </span>
+        </label>
         <div className="mt-5 flex justify-end gap-2">
           <Button variant="ghost" onClick={onClose}>
             {t.studio.workflows.cancel}

--- a/website/src/lib/studio.ts
+++ b/website/src/lib/studio.ts
@@ -326,7 +326,7 @@ async function streamSse(
 }
 
 export function runWorkflow(
-  body: { file: string; inputs?: Record<string, string>; provider?: string; resume?: string | boolean; fromStep?: string; feedback?: string },
+  body: { file: string; inputs?: Record<string, string>; provider?: string; resume?: string | boolean; fromStep?: string; feedback?: string; materialize?: boolean },
   onEvent: SseHandler,
   signal?: AbortSignal,
 ) {


### PR DESCRIPTION
把 #76 的 `--materialize` 产品化进 Studio。工作流输入框加复选框「开发项目（把生成的代码写成真实文件）」；勾选后跑完把开发步产出落盘到 `<数据目录>/scaffold/<工作流名>/`，运行日志显示路径。不勾=原样。

## 改动
- `RunManager`/`studio.ts`：RunRequest + runWorkflow body 加 `materialize` 透传。
- `web/server.js` `/api/run`：materialize 时拼 `--materialize <dir>`（落到 DATA_DIR/scaffold/）。
- `WorkflowsPanel` 输入框：复选框 UI。

## 测试
website 构建通过；本地 server 实测：勾选跑「需求转项目脚手架」→ /api/run 返回「已落盘 6 个文件」，生成完整 Node 计算器脚手架(package.json/bin/lib/test/README)。