### PR TITLE
QA 边界 bug 修复：materialize CRLF/越界、install 重名、对比平局可信度

### DIFF
--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -46,7 +46,7 @@ export function collectRoleFiles(agentsDir: string): RoleFile[] {
       const full = join(dir, entry);
       const st = statSync(full);
       if (st.isDirectory()) {
-        walk(full, category || entry); // 顶层目录名作 category，再深则沿用
+        walk(full, category ? `${category}/${entry}` : entry); // 用完整相对目录作 category，避免嵌套分类重名
       } else if (entry.endsWith('.md') && !/^(README|CONTRIBUTING|LICENSE|SECURITY)/i.test(entry)) {
         const head = readFileSync(full, 'utf-8').slice(0, 400);
         if (!/^---[\s\S]*?\bname\s*:/.test(head)) continue; // 必须有 name frontmatter
@@ -79,7 +79,8 @@ export function installRoles(
   const files: string[] = [];
   if (!opts.dryRun && roles.length) mkdirSync(destDir, { recursive: true });
   for (const r of roles) {
-    const outName = `${r.category}-${r.id}${target.ext}`;
+    // 文件名用完整分类路径拍平(a/b → a-b)，避免嵌套分类下同名角色互相覆盖
+    const outName = `${r.category.replace(/\//g, '-')}-${r.id}${target.ext}`;
     const outPath = join(destDir, outName);
     if (!opts.dryRun) writeFileSync(outPath, readFileSync(r.absPath, 'utf-8'), 'utf-8');
     files.push(outName);

--- a/src/cli/materialize.ts
+++ b/src/cli/materialize.ts
@@ -50,7 +50,7 @@ function pathFromFenceInfo(info: string): string | null {
  * 解析文本里的"文件块"。返回 [{path, content}]，按出现顺序；同路径后者覆盖前者。
  */
 export function parseFileBlocks(text: string): FileBlock[] {
-  const lines = text.split('\n');
+  const lines = text.split(/\r?\n/); // 容忍 CRLF：否则尾随 \r 会让围栏正则匹配不上、整体失效
   const blocks: FileBlock[] = [];
   let lastNonBlank = ''; // 紧邻围栏的上一非空行（用于取标题路径）
 
@@ -90,9 +90,10 @@ export function parseFileBlocks(text: string): FileBlock[] {
  */
 export function safeRelPath(candidate: string, destDir: string): string | null {
   let p = candidate.trim().replace(/^\.\//, '');
-  if (!p || p.startsWith('/') || p.startsWith('~') || p.startsWith('\\') || /^[a-zA-Z]:[\\/]/.test(p)) return null;
+  if (!p || p.startsWith('/') || p.startsWith('~') || p.startsWith('\\') || /^[a-zA-Z]:/.test(p)) return null;
   const rel = normalize(p);
   if (rel.startsWith('..' + sep) || rel === '..' || rel.includes(sep + '..' + sep)) return null;
+  if (rel === '.' || rel === '') return null; // 规整后指向目标根本身（如 "foo/.."）→ 拒绝，避免写到目录上 EISDIR
   const full = resolve(destDir, rel);
   const base = resolve(destDir);
   if (full !== base && !full.startsWith(base + sep)) return null;

--- a/src/core/compare.ts
+++ b/src/core/compare.ts
@@ -107,7 +107,9 @@ export function aggregateVerdict(j1: JudgeScore, j2: JudgeScore): CompareVerdict
   const baseScore = (j1.scoreB + j2.scoreA) / 2;
   const p1 = j1.scoreA - j1.scoreB;
   const p2 = j2.scoreB - j2.scoreA;
-  const consistent = Math.sign(p1) === Math.sign(p2) && p1 !== 0;
+  // 双向同向即可信：都判多智能体更好 / 都判基线更好 / 双向都判平(p1==p2==0,真平局也是一致)。
+  // 仅当两向矛盾(一向说多、一向说基线)才算低可信(位置偏置)。
+  const consistent = Math.sign(p1) === Math.sign(p2);
   const winner = multiScore > baseScore ? 'multi-agent' : baseScore > multiScore ? 'baseline' : 'tie';
   return { multiScore, baseScore, winner, consistent, reasons: [j1.reason, j2.reason].filter(Boolean) };
 }

--- a/test/compare-lib.ts
+++ b/test/compare-lib.ts
@@ -60,6 +60,11 @@ test('双向都判基线更高 → 基线胜', () => {
   const v = aggregateVerdict({ scoreA: 5, scoreB: 8, reason: '' }, { scoreA: 9, scoreB: 6, reason: '' });
   assert(v.winner === 'baseline', `应基线胜, 实际 ${v.winner}`);
 });
+test('双向都判平局 → 高可信(真平局也是一致,非位置偏置)', () => {
+  const v = aggregateVerdict({ scoreA: 7, scoreB: 7, reason: '' }, { scoreA: 7, scoreB: 7, reason: '' });
+  assert(v.winner === 'tie', `应平局, 实际 ${v.winner}`);
+  assert(v.consistent === true, '双向都判平应算高可信(判官一致)');
+});
 test('两向矛盾(位置偏置) → 低可信', () => {
   // j1: A=multi 8 > B=base 6 (说 multi 好)；j2: A=base 8 > B=multi 6 (也说"A"好=base 好) → 矛盾
   const v = aggregateVerdict({ scoreA: 8, scoreB: 6, reason: '' }, { scoreA: 8, scoreB: 6, reason: '' });

--- a/test/install.ts
+++ b/test/install.ts
@@ -63,6 +63,22 @@ test('--category 过滤 + dry-run 不写文件', () => {
   rmSync(dest, { recursive: true, force: true });
 });
 
+test('嵌套分类同名角色不互相覆盖(用完整路径拍平)', () => {
+  const s = mkdtempSync(join(tmpdir(), 'ao-install-nest-'));
+  mkdirSync(join(s, 'game', 'unity'), { recursive: true });
+  mkdirSync(join(s, 'game', 'godot'), { recursive: true });
+  const role = (n: string) => `---\nname: ${n}\ndescription: d\n---\n\n${n}`;
+  writeFileSync(join(s, 'game', 'unity', 'dev.md'), role('UnityDev'));
+  writeFileSync(join(s, 'game', 'godot', 'dev.md'), role('GodotDev'));
+  const dest = mkdtempSync(join(tmpdir(), 'ao-install-nest-dest-'));
+  const res = installRoles(s, INSTALL_TARGETS['claude-code'], { home: dest, cwd: dest });
+  assert(res.installed === 2, `两个嵌套同名 dev 应都装上, 实际 ${res.installed}`);
+  const files = readdirSync(join(dest, '.claude', 'agents')).sort();
+  assert(files.length === 2, `应 2 个不重名文件, 实际 ${files.join(',')}`);
+  rmSync(s, { recursive: true, force: true });
+  rmSync(dest, { recursive: true, force: true });
+});
+
 rmSync(src, { recursive: true, force: true });
 
 console.log(`\n  结果: ${passed} 通过, ${failed} 失败\n`);

--- a/test/materialize.ts
+++ b/test/materialize.ts
@@ -70,6 +70,13 @@ test('四反引号外层可包裹含三反引号的文件(README 嵌套围栏)',
   assert(fs[1].path === 'src/a.ts', '后续文件不应丢失');
 });
 
+test('CRLF 换行也能正确解析(不被尾随 \\r 破坏)', () => {
+  const txt = '### a.ts\r\n```ts\r\nconst a=1\r\n```\r\n';
+  const fs = parseFileBlocks(txt);
+  assert(fs.length === 1 && fs[0].path === 'a.ts', `CRLF 应正常解析, 实际 ${JSON.stringify(fs)}`);
+  assert(fs[0].content.indexOf('\r') === -1, '内容不应残留 \\r');
+});
+
 test('同路径后者覆盖前者', () => {
   const fs = parseFileBlocks('### a.ts\n```ts\nold\n```\n### a.ts\n```ts\nnew\n```\n');
   assert(fs.length === 1 && fs[0].content === 'new', `应后者覆盖: ${JSON.stringify(fs)}`);
@@ -84,6 +91,8 @@ test('.. 逃逸拒绝', () => assert(safeRelPath('../escape.ts', D) === null, '.
 test('深层 .. 逃逸拒绝', () => assert(safeRelPath('a/../../b.ts', D) === null, 'deep escape should be null'));
 test('~ 家目录拒绝', () => assert(safeRelPath('~/x.ts', D) === null, '~ should be null'));
 test('Windows 盘符拒绝', () => assert(safeRelPath('C:\\x.ts', D) === null, 'win abs should be null'));
+test('Windows 盘符相对(C:foo,无斜杠)也拒绝', () => assert(safeRelPath('C:foo.ts', D) === null, 'drive-relative should be null'));
+test('规整后指向根本身(foo/..)拒绝(防 EISDIR)', () => assert(safeRelPath('foo/..', D) === null, '"." should be null'));
 
 console.log('\n─── materializeFromResult ───');
 const mkResult = (steps: { id: string; status: string; output?: string }[]) => ({ steps } as unknown as WorkflowResult);


### PR DESCRIPTION
QA 边界审计（针对本会话新增代码）发现并修复：

## HIGH
- **materialize CRLF**：`parseFileBlocks` 按 `\n` 切割，CRLF 输入残留 `\r` 使围栏正则匹配不上 → `--materialize` 静默写出 0 文件。改 `split(/\r?\n/)`。
- **materialize 越界写目录**：`safeRelPath("foo/..")` 规整为 `"."` 通过所有守卫 → `writeFileSync(destDir)` 抛 EISDIR 中断整个落盘。改为拒绝 `.`/空。

## MED
- **install 重名覆盖**：嵌套分类 `a/b/role` 与 `a/x/role` 都拍成 `a-role.md` 互相覆盖。改用完整分类路径拍平。
- **对比平局可信度**：`aggregateVerdict` 双向都判平局时被误标"低可信(位置偏置)"。改为双向同向(含都判平)即高可信。

## LOW
- 收紧 Windows 盘符相对路径 `C:foo` 判定。

## 测试
每项加回归测试；全套 npm test **329 通过**。