### PR TITLE
报告导出:Word / PDF / Excel + Skill / 可执行计划

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,22 @@
 {
   "name": "agency-orchestrator",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agency-orchestrator",
-      "version": "0.7.5",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",
         "@modelcontextprotocol/sdk": "^1.28.0",
         "agency-agents-zh": "^1.2.2",
+        "html-to-docx": "^1.8.0",
         "js-yaml": "^4.1.0",
-        "superpowers-zh": "^1.5.0"
+        "marked": "^18.0.5",
+        "superpowers-zh": "^1.5.0",
+        "xlsx": "^0.18.5"
       },
       "bin": {
         "agency-orchestrator": "dist/cli.js",
@@ -92,6 +95,93 @@
         }
       }
     },
+    "node_modules/@oozcitak/dom": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.6.tgz",
+      "integrity": "sha512-k4uEIa6DI3FCrFJMGq/05U/59WnS9DjME0kaPqBRCJAqBTkmopbYV1Xs4qFKbDJ/9wOg8W97p+1E0heng/LH7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@oozcitak/infra": "1.0.5",
+        "@oozcitak/url": "1.0.0",
+        "@oozcitak/util": "8.3.4"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@oozcitak/infra": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-1.0.5.tgz",
+      "integrity": "sha512-o+zZH7M6l5e3FaAWy3ojaPIVN5eusaYPrKm6MZQt0DKNdgXa2wDYExjpP0t/zx+GoQgQKzLu7cfD8rHCLt8JrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@oozcitak/util": "8.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/@oozcitak/infra/node_modules/@oozcitak/util": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-8.0.0.tgz",
+      "integrity": "sha512-+9Hq6yuoq/3TRV/n/xcpydGBq2qN2/DEDMqNTG7rm95K6ZE2/YY/sPyx62+1n8QsE9O26e5M1URlXsk+AnN9Jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/@oozcitak/url": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oozcitak/url/-/url-1.0.0.tgz",
+      "integrity": "sha512-LGrMeSxeLzsdaitxq3ZmBRVOrlRRQIgNNci6L0VRnOKlJFuRIkNm4B+BObXPCJA6JT5bEJtrrwjn30jueHJYZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@oozcitak/infra": "1.0.3",
+        "@oozcitak/util": "1.0.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@oozcitak/url/node_modules/@oozcitak/infra": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-1.0.3.tgz",
+      "integrity": "sha512-9O2wxXGnRzy76O1XUxESxDGsXT5kzETJPvYbreO4mv6bqe1+YSuux2cZTagjJ/T4UfEwFJz5ixanOqB0QgYAag==",
+      "license": "MIT",
+      "dependencies": {
+        "@oozcitak/util": "1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/@oozcitak/url/node_modules/@oozcitak/infra/node_modules/@oozcitak/util": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-1.0.1.tgz",
+      "integrity": "sha512-dFwFqcKrQnJ2SapOmRD1nQWEZUtbtIy9Y6TyJquzsalWNJsKIPxmTI0KG6Ypyl8j7v89L2wixH9fQDNrF78hKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/@oozcitak/url/node_modules/@oozcitak/util": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-1.0.2.tgz",
+      "integrity": "sha512-4n8B1cWlJleSOSba5gxsMcN4tO8KkkcvXhNWW+ADqvq9Xj+Lrl9uCa90GRpjekqQJyt84aUX015DG81LFpZYXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/@oozcitak/util": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-8.3.4.tgz",
+      "integrity": "sha512-6gH/bLQJSJEg7OEpkH4wGQdA8KXHRbzL1YkGyUO12YNAgV3jxKy4K9kvfXj4+9T0OLug5k58cnPCKSSIKzp7pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/@types/js-yaml": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
@@ -120,6 +210,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/agency-agents-zh": {
@@ -191,6 +290,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/browser-split": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.1.tgz",
+      "integrity": "sha512-JhvgRb2ihQhsljNda3BI8/UcRHVzrVwo3Q+P8vDtSiyobXuFpuZ9mq+MbRGMnC22CjW3RrfXdg6j6ITX8M+7Ow==",
+      "license": "MIT"
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -228,6 +333,43 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -269,6 +411,12 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -284,6 +432,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -326,6 +486,67 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
+    "node_modules/domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -353,6 +574,37 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/ent": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.2.tgz",
+      "integrity": "sha512-kKvD1tO6BM+oK9HzCPpUdRb4vKFQY/FPTFmurMvh6LlN68VMrdj77w8yp51/kDbpkFOS9J8w5W6zIzgM2H8/hw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "punycode": "^1.4.1",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/error": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/error/-/error-4.4.0.tgz",
+      "integrity": "sha512-SNDKualLUtT4StGFP7xNfuFybL2f6iJujFtrWuvJqGbVQGaN+adE23veqzPz1hjUjTunLi2EnJ+0SJxtbJreKw==",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "string-template": "~0.2.0",
+        "xtend": "~4.0.0"
       }
     },
     "node_modules/es-define-property": {
@@ -398,6 +650,14 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ev-store": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ev-store/-/ev-store-7.0.0.tgz",
+      "integrity": "sha512-otazchNRnGzp2YarBJ+GXKVGvhxVATB1zmaStxJBYet0Dyq7A9VhH8IUEB/gRcL6Ch52lfpgPTRJ2m49epyMsQ==",
+      "dependencies": {
+        "individual": "^3.0.0"
       }
     },
     "node_modules/eventsource": {
@@ -534,6 +794,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
@@ -589,6 +858,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "license": "MIT",
+      "dependencies": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -606,6 +885,21 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -632,6 +926,88 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/html-to-docx": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/html-to-docx/-/html-to-docx-1.8.0.tgz",
+      "integrity": "sha512-IiMBWIqXM4+cEsW//RKoonWV7DlXAJBmmKI73XJSVWTIXjGUaxSr2ck1jqzVRZknpvO8xsFnVicldKVAWrBYBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@oozcitak/dom": "1.15.6",
+        "@oozcitak/util": "8.3.4",
+        "color-name": "^1.1.4",
+        "html-entities": "^2.3.3",
+        "html-to-vdom": "^0.7.0",
+        "image-size": "^1.0.0",
+        "image-to-base64": "^2.2.0",
+        "jszip": "^3.7.1",
+        "lodash": "^4.17.21",
+        "mime-types": "^2.1.35",
+        "nanoid": "^3.1.25",
+        "virtual-dom": "^2.1.1",
+        "xmlbuilder2": "2.1.2"
+      }
+    },
+    "node_modules/html-to-docx/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/html-to-docx/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/html-to-vdom": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/html-to-vdom/-/html-to-vdom-0.7.0.tgz",
+      "integrity": "sha512-k+d2qNkbx0JO00KezQsNcn6k2I/xSBP4yXYFLvXbcasTTDh+RDLUJS3puxqyNnpdyXWRHFGoKU7cRmby8/APcQ==",
+      "license": "ISC",
+      "dependencies": {
+        "ent": "^2.0.0",
+        "htmlparser2": "^3.8.2"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
       }
     },
     "node_modules/http-errors": {
@@ -670,6 +1046,41 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/image-size": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "license": "MIT",
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
+    "node_modules/image-to-base64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/image-to-base64/-/image-to-base64-2.2.0.tgz",
+      "integrity": "sha512-Z+aMwm/91UOQqHhrz7Upre2ytKhWejZlWV/JxUTD1sT7GWWKFDJUEV5scVQKnkzSgPHFuQBUEWcanO+ma0PSVw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.0"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/individual": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/individual/-/individual-3.0.0.tgz",
+      "integrity": "sha512-rUY5vtT748NMRbEMrTNiFfy29BgGZwGXUi2NFUVMWQrogSLzlJvQV9eeMWi+g1aVaQ53tpyLAQtd5x/JH0Nh1g=="
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -694,10 +1105,43 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -738,6 +1182,75 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -794,11 +1307,38 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/min-document": {
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.2.tgz",
+      "integrity": "sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A==",
+      "license": "MIT",
+      "dependencies": {
+        "dom-walk": "^0.1.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -807,6 +1347,32 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/next-tick": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
+      "integrity": "sha512-f7h4svPtl+QidoBv4taKXUjJ70G2asaZ8G28nS0OkqaalX8dwwrtWtyxEDPK62AC00ur/+/E0pUwBwY5EPn15Q==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/object-assign": {
@@ -851,6 +1417,12 @@
         "wrappy": "1"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -888,6 +1460,21 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -900,6 +1487,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.0",
@@ -914,6 +1507,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
       }
     },
     "node_modules/range-parser": {
@@ -940,6 +1542,20 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -963,6 +1579,43 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/safer-buffer": {
@@ -1015,6 +1668,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -1115,6 +1774,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1123,6 +1794,20 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-template": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+      "integrity": "sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw=="
     },
     "node_modules/superpowers-zh": {
       "version": "1.5.0",
@@ -1144,6 +1829,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/type-is": {
       "version": "2.0.1",
@@ -1189,6 +1880,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -1196,6 +1893,38 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/virtual-dom": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/virtual-dom/-/virtual-dom-2.1.1.tgz",
+      "integrity": "sha512-wb6Qc9Lbqug0kRqo/iuApfBpJJAq14Sk1faAnSmtqXiwahg7PVTvWMs9L02Z8nNIMqbwsxzBAA90bbtRLbw0zg==",
+      "license": "MIT",
+      "dependencies": {
+        "browser-split": "0.0.1",
+        "error": "^4.3.0",
+        "ev-store": "^7.0.0",
+        "global": "^4.3.0",
+        "is-object": "^1.0.1",
+        "next-tick": "^0.2.2",
+        "x-is-array": "0.1.0",
+        "x-is-string": "0.1.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -1213,11 +1942,115 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/x-is-array": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/x-is-array/-/x-is-array-0.1.0.tgz",
+      "integrity": "sha512-goHPif61oNrr0jJgsXRfc8oqtYzvfiMJpTqwE7Z4y9uH+T3UozkGqQ4d2nX9mB9khvA8U2o/UbPOFjgC7hLWIA=="
+    },
+    "node_modules/x-is-string": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+      "integrity": "sha512-GojqklwG8gpzOVEVki5KudKNoq7MbbjYZCbyWzEz7tyPA7eleiE0+ePwOWQQRb5fm86rD3S8Tc0tSFf3AOv50w=="
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/xmlbuilder2": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-2.1.2.tgz",
+      "integrity": "sha512-PI710tmtVlQ5VmwzbRTuhmVhKnj9pM8Si+iOZCV2g2SNo3gCrpzR2Ka9wNzZtqfD+mnP+xkrqoNy0sjKZqP4Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@oozcitak/dom": "1.15.5",
+        "@oozcitak/infra": "1.0.5",
+        "@oozcitak/util": "8.3.3"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/xmlbuilder2/node_modules/@oozcitak/dom": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.5.tgz",
+      "integrity": "sha512-L6v3Mwb0TaYBYgeYlIeBaHnc+2ZEaDSbFiRm5KmqZQSoBlbPlf+l6aIH/sD5GUf2MYwULw00LT7+dOnEuAEC0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@oozcitak/infra": "1.0.5",
+        "@oozcitak/url": "1.0.0",
+        "@oozcitak/util": "8.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/xmlbuilder2/node_modules/@oozcitak/dom/node_modules/@oozcitak/util": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-8.0.0.tgz",
+      "integrity": "sha512-+9Hq6yuoq/3TRV/n/xcpydGBq2qN2/DEDMqNTG7rm95K6ZE2/YY/sPyx62+1n8QsE9O26e5M1URlXsk+AnN9Jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/xmlbuilder2/node_modules/@oozcitak/util": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-8.3.3.tgz",
+      "integrity": "sha512-Ufpab7G5PfnEhQyy5kDg9C8ltWJjsVT1P/IYqacjstaqydG4Q21HAT2HUZQYBrC/a1ZLKCz87pfydlDvv8y97w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agency-orchestrator",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Multi-agent YAML workflow engine — 216 AI roles, auto DAG parallelism, zero code. One sentence → multiple AI roles collaborate → complete plan in minutes. 10 LLM providers, 7 need no API key.",
   "keywords": [
     "multi-agent",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "eval:baseline": "npx tsx eval/run-eval.ts --save-baseline",
     "build:studio": "npm --prefix website install && npm --prefix website run build",
     "verify:release": "node scripts/verify-cli.mjs && node scripts/verify-frontend.mjs",
-    "test": "npx tsx test/run.ts && npx tsx test/condition.ts && npx tsx test/cli.ts && npx tsx test/cli-base.ts && npx tsx test/parse-inputs.ts && npx tsx test/compose.ts && npx tsx test/demo.ts && npx tsx test/factory-custom.ts && npx tsx test/azure-compat.ts && npx tsx test/connector-continuation.ts && npx tsx test/connector-stall.ts && npx tsx test/compare-lib.ts && npx tsx test/install.ts && npx tsx test/materialize.ts && npx tsx test/paths.ts && npx tsx test/skills.ts && npx tsx test/step-llm.ts && npx tsx test/step-llm-yaml.ts && npx tsx test/stdin-limit.ts && npx tsx test/compose-name.ts && npx tsx test/team.ts && npx tsx test/prompt.ts && npx tsx test/upgrade.ts && npx tsx test/resume.ts && npx tsx test/feedback.ts && npx tsx test/human-input.ts && npx tsx test/init.ts && npx tsx test/roles.ts && npx tsx test/eval-gate.ts && npx tsx test/validate-report.ts && npx tsx test/workflows.ts && npx tsx test/timeout.ts && npx tsx test/inputs.ts && npx tsx test/e2e.ts && npx tsx test/e2e-condition.ts && npx tsx test/e2e-loop.ts && npx tsx test/detect-providers.ts && npx tsx test/canvas-graph.ts && npx tsx test/creative-prompts.ts && npx tsx test/web-server.ts && npx tsx test/mcp.ts",
+    "test": "npx tsx test/run.ts && npx tsx test/condition.ts && npx tsx test/cli.ts && npx tsx test/cli-base.ts && npx tsx test/parse-inputs.ts && npx tsx test/compose.ts && npx tsx test/demo.ts && npx tsx test/factory-custom.ts && npx tsx test/azure-compat.ts && npx tsx test/connector-continuation.ts && npx tsx test/connector-stall.ts && npx tsx test/compare-lib.ts && npx tsx test/install.ts && npx tsx test/materialize.ts && npx tsx test/paths.ts && npx tsx test/skills.ts && npx tsx test/step-llm.ts && npx tsx test/step-llm-yaml.ts && npx tsx test/stdin-limit.ts && npx tsx test/compose-name.ts && npx tsx test/team.ts && npx tsx test/prompt.ts && npx tsx test/upgrade.ts && npx tsx test/resume.ts && npx tsx test/feedback.ts && npx tsx test/human-input.ts && npx tsx test/init.ts && npx tsx test/roles.ts && npx tsx test/eval-gate.ts && npx tsx test/validate-report.ts && npx tsx test/workflows.ts && npx tsx test/timeout.ts && npx tsx test/inputs.ts && npx tsx test/e2e.ts && npx tsx test/e2e-condition.ts && npx tsx test/e2e-loop.ts && npx tsx test/detect-providers.ts && npx tsx test/canvas-graph.ts && npx tsx test/creative-prompts.ts && npx tsx test/export-convert.ts && npx tsx test/web-server.ts && npx tsx test/mcp.ts",
     "prepublishOnly": "npm run build && npm run build:studio && npm run verify:release"
   },
   "files": [
@@ -90,8 +90,11 @@
     "@anthropic-ai/sdk": "^0.52.0",
     "@modelcontextprotocol/sdk": "^1.28.0",
     "agency-agents-zh": "^1.2.2",
+    "html-to-docx": "^1.8.0",
     "js-yaml": "^4.1.0",
-    "superpowers-zh": "^1.5.0"
+    "marked": "^18.0.5",
+    "superpowers-zh": "^1.5.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@
  *   ao plan workflow.yaml
  *   ao roles --agents-dir ./agents
  */
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, writeFileSync } from 'node:fs';
 import { resolve, join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execSync, spawn } from 'node:child_process';
@@ -132,6 +132,7 @@ async function handleRun(): Promise<void> {
     console.error('用法: ao run <workflow.yaml> [--input key=value ...]');
     console.error('  或: ao run --team <名字> "你的任务"   # 用已保存的团队跑新任务');
     console.error('  --materialize <目录>     把开发步产出的「### 路径 + 代码围栏」文件块落盘成真实项目脚手架');
+    console.error('  --export <格式>          把本次产出导出:docx/pdf/xlsx(给人)或 skill/plan(给编码 agent 执行)');
     console.error('  --compare                跑完后再跑单次基线 + 盲评，并排对比多智能体 vs 单次');
     console.error('  --judge-provider/--judge-model   --compare 时指定评审模型(默认用生成模型)');
     process.exit(1);
@@ -233,6 +234,34 @@ async function handleRun(): Promise<void> {
         console.log(`\n  ⚠️ --materialize：未在产出里找到"文件块"（约定格式：### 路径 + 代码围栏）。`);
       }
       if (mat.skipped.length) console.log(`  ⛔ 跳过 ${mat.skipped.length} 个不安全路径: ${mat.skipped.slice(0, 5).join(', ')}`);
+    }
+
+    // --export <fmt>：把本次产出导出成 Word/PDF/Excel,或 Skill/可执行计划(给编码 agent 跑)
+    const exportFmt = getArgValue('--export');
+    if (exportFmt) {
+      const allowed = ['docx', 'pdf', 'xlsx', 'skill', 'plan'];
+      if (!allowed.includes(exportFmt)) {
+        console.error(`\n  ⚠️ --export 仅支持: ${allowed.join(' / ')}`);
+      } else {
+        const md = result.steps
+          .filter(s => s.status === 'completed' && s.output)
+          .map(s => `## ${s.agentName || s.role || s.id}\n\n${s.output}`)
+          .join('\n\n---\n\n');
+        if (!md) {
+          console.log(`\n  ⚠️ --export：本次运行没有可导出的产出。`);
+        } else {
+          // 懒加载转换器(xlsx/marked/html-to-docx 较重,仅用到时才载)
+          const { exportMarkdown } = await import('./export/convert.js');
+          const r = await exportMarkdown(md, exportFmt as 'docx' | 'pdf' | 'xlsx' | 'skill' | 'plan', { name: result.name });
+          const safe = (result.name || 'report').replace(/[^一-鿿a-zA-Z0-9_-]+/g, '-').replace(/-+/g, '-').slice(0, 60) || 'report';
+          const out = resolve(`${safe}.${r.ext}`);
+          writeFileSync(out, r.buffer);
+          console.log(`\n  📤 已导出 → ${out}（${r.engine}）`);
+          if (r.ext === 'html' && exportFmt === 'pdf') {
+            console.log(`     (未检测到 pandoc+LaTeX,已输出打印就绪 HTML;浏览器打开 Ctrl-P 存 PDF,或装 pandoc 获更佳排版)`);
+          }
+        }
+      }
     }
 
     process.exit(result.success ? 0 : 1);

--- a/src/export/convert.ts
+++ b/src/export/convert.ts
@@ -1,0 +1,125 @@
+// 把工作流产出的 Markdown 报告转成可用格式。
+//   给人:Word(.docx)/ PDF / Excel(.xlsx,从 Markdown 表格抽)
+//   给机器:Skill(.md + frontmatter,可复用方法论)/ 可执行计划(plan.md,交 Claude Code 执行)
+//
+// 设计(对齐 AO「零配置探测」):有 pandoc 就用它出最好看的 docx/pdf(pdf 走 xelatex 排版最佳);
+// 没 pandoc 则用纯 JS 兜底(marked + html-to-docx)。Excel 一律用 SheetJS(不依赖 pandoc)。
+// n8n 同款思路——转文件是确定性的库调用,不是 LLM。
+
+import { spawnSync } from 'node:child_process';
+import { marked } from 'marked';
+import * as XLSX from 'xlsx';
+import { isOnPath } from '../providers/detect.js';
+
+export type ExportFormat = 'docx' | 'pdf' | 'xlsx' | 'skill' | 'plan';
+export interface ExportResult { buffer: Buffer; ext: string; mime: string; engine: string; }
+
+export function hasPandoc(): boolean {
+  return isOnPath('pandoc');
+}
+
+/** Markdown → HTML(给 docx/pdf 兜底用),套一层基础打印样式。 */
+function mdToHtml(md: string, title = 'Report'): string {
+  const body = marked.parse(md, { async: false }) as string;
+  return `<!doctype html><html><head><meta charset="utf-8"><title>${title}</title>
+<style>body{font-family:system-ui,"PingFang SC","Microsoft YaHei",sans-serif;line-height:1.7;max-width:820px;margin:24px auto;padding:0 16px;color:#1a1a1a}
+h1,h2,h3{line-height:1.3}table{border-collapse:collapse;width:100%}th,td{border:1px solid #ccc;padding:6px 10px}
+pre{background:#f5f5f5;padding:12px;border-radius:6px;overflow:auto}code{font-family:ui-monospace,monospace}
+@media print{body{margin:0}}</style></head><body>${body}</body></html>`;
+}
+
+/** 用 pandoc 把 markdown 转成指定目标(stdout 二进制)。失败/无 pandoc 返回 null。 */
+function pandocConvert(md: string, to: string, extraArgs: string[] = []): Buffer | null {
+  if (!hasPandoc()) return null;
+  const r = spawnSync('pandoc', ['-f', 'markdown', '-t', to, ...extraArgs], {
+    input: md,
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (r.status !== 0 || !r.stdout || r.stdout.length === 0) return null;
+  return Buffer.from(r.stdout);
+}
+
+async function toDocx(md: string): Promise<ExportResult> {
+  const viaPandoc = pandocConvert(md, 'docx');
+  if (viaPandoc) return { buffer: viaPandoc, ext: 'docx', mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', engine: 'pandoc' };
+  // JS 兜底:marked → html → html-to-docx
+  // @ts-expect-error html-to-docx 无类型声明文件
+  const HTMLtoDOCX = (await import('html-to-docx')).default as (html: string, header?: string | null, opts?: unknown) => Promise<Buffer | ArrayBuffer>;
+  const out = await HTMLtoDOCX(mdToHtml(md), null, { table: { row: { cantSplit: true } } });
+  const buffer = Buffer.isBuffer(out) ? out : Buffer.from(out as ArrayBuffer);
+  return { buffer, ext: 'docx', mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', engine: 'html-to-docx' };
+}
+
+function toPdf(md: string): ExportResult {
+  // PDF 排版最好看的是 pandoc + xelatex;无 pandoc 时不硬出丑 PDF,改给打印就绪的 HTML(浏览器 Ctrl-P 存 PDF)。
+  const viaPandoc = pandocConvert(md, 'pdf', ['--pdf-engine=xelatex', '-V', 'CJKmainfont=PingFang SC']);
+  if (viaPandoc) return { buffer: viaPandoc, ext: 'pdf', mime: 'application/pdf', engine: 'pandoc+xelatex' };
+  return { buffer: Buffer.from(mdToHtml(md), 'utf-8'), ext: 'html', mime: 'text/html', engine: 'html-fallback' };
+}
+
+/** 从 Markdown 里的表格抽成 xlsx(每个表格一个 sheet)。没有表格则把全文放一个 sheet 的首列。 */
+function toXlsx(md: string): ExportResult {
+  const wb = XLSX.utils.book_new();
+  const tables = extractMarkdownTables(md);
+  if (tables.length === 0) {
+    const ws = XLSX.utils.aoa_to_sheet(md.split('\n').map((line) => [line]));
+    XLSX.utils.book_append_sheet(wb, ws, 'Report');
+  } else {
+    tables.forEach((t, i) => {
+      const ws = XLSX.utils.aoa_to_sheet(t.rows);
+      XLSX.utils.book_append_sheet(wb, ws, (t.title || `Table${i + 1}`).slice(0, 28));
+    });
+  }
+  const buffer = XLSX.write(wb, { type: 'buffer', bookType: 'xlsx' }) as Buffer;
+  return { buffer, ext: 'xlsx', mime: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', engine: 'sheetjs' };
+}
+
+/** 解析 markdown 表格(连续的 | … | 行),标题取表格上方最近的标题行。 */
+export function extractMarkdownTables(md: string): Array<{ title?: string; rows: string[][] }> {
+  const lines = md.split('\n');
+  const tables: Array<{ title?: string; rows: string[][] }> = [];
+  let lastHeading: string | undefined;
+  let i = 0;
+  const splitRow = (line: string) => line.trim().replace(/^\||\|$/g, '').split('|').map((c) => c.trim());
+  while (i < lines.length) {
+    const line = lines[i];
+    const h = line.match(/^#{1,6}\s+(.+)/);
+    if (h) { lastHeading = h[1].trim(); i++; continue; }
+    const isRow = /^\s*\|.*\|\s*$/.test(line);
+    const isSep = i + 1 < lines.length && /^\s*\|[\s:|-]+\|\s*$/.test(lines[i + 1]);
+    if (isRow && isSep) {
+      const rows: string[][] = [splitRow(line)];
+      i += 2; // 跳过表头 + 分隔行
+      while (i < lines.length && /^\s*\|.*\|\s*$/.test(lines[i])) { rows.push(splitRow(lines[i])); i++; }
+      tables.push({ title: lastHeading, rows });
+      continue;
+    }
+    i++;
+  }
+  return tables;
+}
+
+/** 把报告包成可复用 Skill(.md + frontmatter)或可执行计划(交 Claude Code 跑)。 */
+function toSkillOrPlan(md: string, format: 'skill' | 'plan', opts?: { name?: string; description?: string }): ExportResult {
+  const name = (opts?.name || 'generated-plan').replace(/[^一-鿿a-zA-Z0-9_-]/g, '-').replace(/-+/g, '-').toLowerCase();
+  const desc = opts?.description || '由 Agency Orchestrator 多智能体协作生成的方法论 / 计划';
+  let content: string;
+  if (format === 'skill') {
+    content = `---\nname: ${name}\ndescription: ${desc}\n---\n\n${md}\n`;
+  } else {
+    // 可执行计划:给 Claude Code 等编码 agent 的执行说明(把"看的报告"变成"做的指令")
+    content = `# 执行计划(由 Agency Orchestrator 生成)\n\n> 你是编码执行 agent。请**严格按下面的计划自动执行直到完成**,对不明确处用合理默认值,不要反问。完成后自检是否满足计划目标。\n\n---\n\n${md}\n`;
+  }
+  return { buffer: Buffer.from(content, 'utf-8'), ext: 'md', mime: 'text/markdown', engine: 'wrap' };
+}
+
+export async function exportMarkdown(md: string, format: ExportFormat, opts?: { name?: string; description?: string }): Promise<ExportResult> {
+  switch (format) {
+    case 'docx': return toDocx(md);
+    case 'pdf': return toPdf(md);
+    case 'xlsx': return toXlsx(md);
+    case 'skill': return toSkillOrPlan(md, 'skill', opts);
+    case 'plan': return toSkillOrPlan(md, 'plan', opts);
+    default: throw new Error(`不支持的导出格式: ${format}`);
+  }
+}

--- a/test/export-convert.ts
+++ b/test/export-convert.ts
@@ -1,0 +1,65 @@
+/**
+ * export/convert.ts 测试:真生成各格式并校验。
+ * docx/xlsx 是二进制(zip),验魔数 + 读回内容;skill/plan 验包装;表格解析验正确性。
+ */
+import * as XLSX from 'xlsx';
+import { exportMarkdown, extractMarkdownTables, hasPandoc } from '../src/export/convert.js';
+
+let passed = 0, failed = 0;
+function assert(c: boolean, m: string): void { if (c) { console.log(`  ✅ ${m}`); passed++; } else { console.log(`  ❌ ${m}`); failed++; } }
+
+console.log('\n─── export/convert ───');
+
+const MD = `# 进销存系统报告
+
+## 概述
+这是一份多智能体协作生成的报告。
+
+## 模块清单
+
+| 模块 | 负责人 | 状态 |
+|------|--------|------|
+| 入库 | 后端 | 完成 |
+| 出库 | 后端 | 进行中 |
+
+- 要点 A
+- 要点 B
+`;
+
+console.log(`  (本机 pandoc: ${hasPandoc() ? '有' : '无,走 JS 兜底'})`);
+
+// 表格解析
+const tables = extractMarkdownTables(MD);
+assert(tables.length === 1, `解析出 1 个表格(${tables.length})`);
+assert(tables[0].rows.length === 3, '表格 3 行(表头+2数据)');
+assert(tables[0].rows[1][0] === '入库', '表格首数据格=入库');
+assert(tables[0].title === '模块清单', '表格标题取上方 heading');
+
+// docx:zip 魔数 PK
+const docx = await exportMarkdown(MD, 'docx');
+assert(docx.ext === 'docx' && docx.buffer.length > 0, `docx 非空(${docx.engine}, ${docx.buffer.length}B)`);
+assert(docx.buffer[0] === 0x50 && docx.buffer[1] === 0x4b, 'docx 是有效 zip(PK 魔数)');
+
+// xlsx:读回验数据
+const xlsx = await exportMarkdown(MD, 'xlsx');
+assert(xlsx.ext === 'xlsx' && xlsx.buffer[0] === 0x50, 'xlsx 是有效 zip');
+const wb = XLSX.read(xlsx.buffer, { type: 'buffer' });
+const ws = wb.Sheets[wb.SheetNames[0]];
+const aoa = XLSX.utils.sheet_to_json(ws, { header: 1 }) as string[][];
+assert(aoa.some((r) => r.includes('入库')), 'xlsx 读回含"入库"');
+
+// skill:frontmatter
+const skill = await exportMarkdown(MD, 'skill', { name: '进销存方案', description: '测试' });
+const st = skill.buffer.toString('utf-8');
+assert(skill.ext === 'md' && /^---\nname:/.test(st) && st.includes('description:'), 'skill 带 frontmatter');
+
+// plan:执行包装
+const plan = await exportMarkdown(MD, 'plan');
+assert(plan.buffer.toString('utf-8').includes('严格按下面的计划自动执行'), 'plan 含执行指令包装');
+
+// pdf:有 pandoc→pdf,无→html 兜底(都可接受)
+const pdf = await exportMarkdown(MD, 'pdf');
+assert(['pdf', 'html'].includes(pdf.ext), `pdf 产出 ${pdf.ext}(${pdf.engine})`);
+
+console.log(`\n  结果: ${passed} 通过, ${failed} 失败\n`);
+if (failed > 0) process.exit(1);

--- a/test/web-server.ts
+++ b/test/web-server.ts
@@ -96,6 +96,15 @@ try {
     // 成环：a → b → a，validateWorkflow 应拒
     const cycleBody = { ...okBody, edges: [{ id: 'a->b', source: 'a', target: 'b' }, { id: 'b->a', source: 'b', target: 'a' }] };
     assert(await post(base, '/api/workflows/graph', cycleBody) === 400, '/api/workflows/graph 成环 → 400 被校验拦截');
+
+    // ── 报告导出 /api/export ──
+    assert(await post(base, '/api/export', { format: 'docx' }) === 400, '/api/export 缺 markdown → 400');
+    assert(await post(base, '/api/export', { markdown: '# x', format: 'rtf' }) === 400, '/api/export 非法格式 → 400');
+    const expDocx = await fetch(base + '/api/export', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ markdown: '# 标题\n\n| a | b |\n|---|---|\n| 1 | 2 |\n', format: 'docx', name: '测试报告' }) });
+    assert(expDocx.status === 200 && (expDocx.headers.get('content-type') || '').includes('wordprocessingml'), `/api/export docx → 200 + docx mime(${expDocx.status})`);
+    const expSkill = await fetch(base + '/api/export', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ markdown: '# plan', format: 'skill', name: 's' }) });
+    const skillText = await expSkill.text();
+    assert(expSkill.status === 200 && skillText.startsWith('---\nname:'), '/api/export skill → 200 + frontmatter');
   }
 } finally {
   if (server) server.kill('SIGTERM');

--- a/web/server.js
+++ b/web/server.js
@@ -796,6 +796,24 @@ app.post('/api/workflows/graph', async (req, res) => {
   } catch (err) { res.status(500).json({ error: err?.message || String(err) }); }
 });
 
+// ── 报告导出:Markdown → Word / PDF / Excel / Skill / 可执行计划(确定性转换,见 src/export/convert.ts) ──
+app.post('/api/export', async (req, res) => {
+  const { markdown, format, name } = req.body || {};
+  if (!markdown || typeof markdown !== 'string') return res.status(400).json({ error: 'markdown required' });
+  const allowed = ['docx', 'pdf', 'xlsx', 'skill', 'plan'];
+  if (!allowed.includes(format)) return res.status(400).json({ error: `format must be one of ${allowed.join('/')}` });
+  try {
+    const { exportMarkdown } = await import('../dist/export/convert.js');
+    const r = await exportMarkdown(markdown, format, { name: typeof name === 'string' ? name : undefined });
+    const safe = (typeof name === 'string' && name.trim() ? name : 'report').replace(/[^一-鿿a-zA-Z0-9_-]+/g, '-').replace(/-+/g, '-').slice(0, 60) || 'report';
+    res.setHeader('Content-Type', r.mime);
+    // 中文文件名用 RFC 5987 编码,避免 header 非法字符
+    res.setHeader('Content-Disposition', `attachment; filename="export.${r.ext}"; filename*=UTF-8''${encodeURIComponent(safe)}.${r.ext}`);
+    res.setHeader('X-Export-Engine', r.engine);
+    res.send(r.buffer);
+  } catch (err) { res.status(500).json({ error: err?.message || String(err) }); }
+});
+
 // ── Teams / Loadouts: reusable role line-ups, shared with the `ao team` CLI ──
 // Stored in ~/.ao/teams (or AO_TEAMS_DIR) so CLI-saved and Studio-saved teams interoperate.
 app.get('/api/teams', async (_req, res) => {

--- a/website/src/components/studio/RunViewer.tsx
+++ b/website/src/components/studio/RunViewer.tsx
@@ -1,4 +1,4 @@
-import { Check, Copy, Download, Loader2, MessageSquare, Minus, Scale, Square, Terminal, X } from "lucide-react";
+import { Check, ChevronDown, Copy, Download, FileDown, Loader2, MessageSquare, Minus, Scale, Square, Terminal, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useCopy } from "@/components/ui/copy-button";
@@ -7,7 +7,7 @@ import { StepList } from "./StepList";
 import { useRunManager, type PendingInput } from "./RunManager";
 import { BaselineCompareOverlay } from "./BaselineCompareOverlay";
 import { downloadText, safeFilename } from "@/lib/download";
-import type { Workflow } from "@/lib/studio";
+import { downloadExport, type Workflow } from "@/lib/studio";
 import { track } from "@/lib/track";
 import { cn } from "@/lib/utils";
 
@@ -17,6 +17,9 @@ export function RunViewer({ onViewHistory }: { onViewHistory?: () => void }) {
   const run = runs.find((r) => r.id === openId) || null;
   const [showTerminal, setShowTerminal] = useState(false);
   const [showCompare, setShowCompare] = useState(false);
+  const [exportOpen, setExportOpen] = useState(false);
+  const [exporting, setExporting] = useState<string | null>(null);
+  const [exportErr, setExportErr] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const { copied, copy } = useCopy();
 
@@ -46,8 +49,30 @@ export function RunViewer({ onViewHistory }: { onViewHistory?: () => void }) {
     return () => window.removeEventListener("keydown", onKey);
   }, [run, open]);
 
+  const doExport = async (format: "docx" | "pdf" | "xlsx" | "skill" | "plan") => {
+    if (!run || !fullText) return;
+    setExportOpen(false);
+    setExporting(format);
+    setExportErr(null);
+    track("export", { format });
+    try {
+      await downloadExport(fullText, format, run.title);
+    } catch (e: unknown) {
+      setExportErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setExporting(null);
+    }
+  };
+
   if (!run) return null;
   const doneCount = run.steps.filter((s) => s.status === "done").length;
+  const EXPORTS: Array<{ fmt: "docx" | "pdf" | "xlsx" | "skill" | "plan"; label: string }> = [
+    { fmt: "docx", label: lang === "en" ? "Word (.docx)" : "Word 文档 (.docx)" },
+    { fmt: "pdf", label: "PDF" },
+    { fmt: "xlsx", label: lang === "en" ? "Excel (.xlsx)" : "Excel 表格 (.xlsx)" },
+    { fmt: "skill", label: lang === "en" ? "Save as Skill (.md)" : "存为 Skill (.md)" },
+    { fmt: "plan", label: lang === "en" ? "Executable plan (.md)" : "存为可执行计划 (.md)" },
+  ];
 
   return (
     <>
@@ -128,8 +153,8 @@ export function RunViewer({ onViewHistory }: { onViewHistory?: () => void }) {
 
         {/* footer */}
         <div className="flex items-center justify-between gap-2 border-t border-border/60 px-5 py-3">
-          <span className="truncate text-xs text-muted-foreground">
-            {running ? t.studio.run.backgroundHint : run.state === "done" ? t.studio.run.savedToHistory : ""}
+          <span className={cn("truncate text-xs", exportErr ? "text-red-500" : "text-muted-foreground")}>
+            {exportErr ? `导出失败：${exportErr}` : running ? t.studio.run.backgroundHint : run.state === "done" ? t.studio.run.savedToHistory : ""}
           </span>
           <div className="flex shrink-0 gap-2">
             {!!fullText && (
@@ -146,6 +171,30 @@ export function RunViewer({ onViewHistory }: { onViewHistory?: () => void }) {
                   <Download className="size-3.5" />
                   {t.studio.run.downloadMd}
                 </Button>
+                {/* 导出为 Word/PDF/Excel(给人)或 Skill/可执行计划(给机器)*/}
+                <div className="relative">
+                  <Button size="sm" variant="outline" onClick={() => setExportOpen((v) => !v)}>
+                    {exporting ? <Loader2 className="size-3.5 animate-spin" /> : <FileDown className="size-3.5" />}
+                    {lang === "en" ? "Export" : "导出"}
+                    <ChevronDown className="size-3 opacity-60" />
+                  </Button>
+                  {exportOpen && (
+                    <div className="absolute bottom-full right-0 z-10 mb-1 min-w-44 rounded-xl border border-border/60 bg-background/95 p-1.5 shadow-lg backdrop-blur-xl">
+                      {EXPORTS.map((e, i) => (
+                        <div key={e.fmt}>
+                          {i === 3 && <div className="my-1 border-t border-border/50" />}
+                          <button
+                            onClick={() => doExport(e.fmt)}
+                            disabled={!!exporting}
+                            className="block w-full rounded-lg px-3 py-1.5 text-left text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
+                          >
+                            {e.label}
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
               </>
             )}
             {/* 价值时刻:工作流跑完后,一键对比"单个 AI"——直观看多智能体到底强在哪 */}

--- a/website/src/lib/studio.ts
+++ b/website/src/lib/studio.ts
@@ -137,6 +137,28 @@ export type SseHandler = (event: string, data: any) => void;
 
 const API = "/api";
 
+/** 把报告 Markdown 导出成 Word/PDF/Excel/Skill/计划,并触发浏览器下载。 */
+export async function downloadExport(markdown: string, format: "docx" | "pdf" | "xlsx" | "skill" | "plan", name: string): Promise<void> {
+  const res = await fetch(`${API}/export`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ markdown, format, name }),
+  });
+  if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || `导出失败 (${res.status})`);
+  const blob = await res.blob();
+  const cd = res.headers.get("content-disposition") || "";
+  const m = cd.match(/filename\*=UTF-8''([^;]+)/);
+  const fname = m ? decodeURIComponent(m[1]) : `${name}.${format}`;
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = fname;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
 async function getJSON<T>(path: string): Promise<T> {
   const res = await fetch(`${API}${path}`);
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);


### PR DESCRIPTION
把多智能体产出的 Markdown 报告转成可用格式。确定性转换(非 LLM,参考 n8n convert-to-file 用库的做法)。

## 能力
- **给人**:Word(.docx)/ PDF / Excel(.xlsx,从 Markdown 表格抽)
- **给机器**:Skill(.md+frontmatter,可复用方法论)/ 可执行计划(交编码 agent 自动执行)
- 探测 pandoc 用它出最佳 docx/PDF(PDF 走 xelatex);无则纯 JS 兜底(marked+html-to-docx;PDF 退打印就绪 HTML)。Excel 用 SheetJS。

## 入口
- Studio 运行视图「导出 ▾」 · CLI `ao run ... --export docx|pdf|xlsx|skill|plan` · API `POST /api/export`

## 测试
核心单测 11/11、端点冒烟、活体三格式端到端验证、全量套件绿。埋点 export 事件。

发布需 bump 版本(如 0.8.1)。